### PR TITLE
added healthtelemetryfilter to resource registry component

### DIFF
--- a/src/ResourceRegistry/Health/HealthTelemetryFilter.cs
+++ b/src/ResourceRegistry/Health/HealthTelemetryFilter.cs
@@ -1,0 +1,47 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+
+namespace Altinn.ResourceRegistry.Health
+{
+    /// <summary>
+    /// Filter to exclude health check request from Application Insights
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    public class HealthTelemetryFilter : ITelemetryProcessor
+    {
+        private ITelemetryProcessor Next { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HealthTelemetryFilter"/> class.
+        /// </summary>
+        public HealthTelemetryFilter(ITelemetryProcessor next)
+        {
+            Next = next;
+        }
+
+        /// <inheritdoc/>
+        public void Process(ITelemetry item)
+        {
+            if (ExcludeItemTelemetry(item))
+            {
+                return;
+            }
+
+            Next.Process(item);
+        }
+
+        private static bool ExcludeItemTelemetry(ITelemetry item)
+        {
+            RequestTelemetry request = item as RequestTelemetry;
+
+            if (request != null && request.Url.ToString().EndsWith("/health/"))
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
The health check is already available in the repository. So just added the healthtelemetryfilter to exclude requests from applicationInsights

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #18 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
