### PR TITLE
Extended model to store in db to contain owner name

### DIFF
--- a/src/Altinn.ResourceRegistry.Core/Models/CompetentAuthority.cs
+++ b/src/Altinn.ResourceRegistry.Core/Models/CompetentAuthority.cs
@@ -20,5 +20,10 @@ namespace Altinn.ResourceRegistry.Core.Models
         /// The organization code
         /// </summary>
         public string Orgcode { get; set; }
+
+        /// <summary>
+        /// Gets or set the name of the Authority with language support
+        /// </summary>
+        public Dictionary<string, string> Orgname { get; set; }
     }
 }


### PR DESCRIPTION
To support ResourceOwner name to be stored as a part of the resource with full language support.

## Description
Since the model is serialized and stored directly as Jsonb column in postgres the only change is to chnge the model to be able to store it. Altinn II is also changed so all exported resources will fetch ServiceOwner name and append it to this field to enable language support on ech entry

## Related Issue(s)
- #93

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
