### PR TITLE
Fixed double check on resourceid is valid as path and double add of f…

### DIFF
--- a/src/Altinn.ResourceRegistry.Core/Services/ResourceRegistryService.cs
+++ b/src/Altinn.ResourceRegistry.Core/Services/ResourceRegistryService.cs
@@ -81,9 +81,7 @@ namespace Altinn.ResourceRegistry.Core.Services
         public async Task<bool> StorePolicy(ServiceResource serviceResource, Stream fileStream)
         {
             PolicyHelper.IsValidResourcePolicy(serviceResource, fileStream);
-
-            string filePath = $"{serviceResource.Identifier.AsFilePath()}/resourcepolicy.xml";
-            Response<BlobContentInfo> response = await _policyRepository.WritePolicyAsync(filePath, fileStream);
+            Response<BlobContentInfo> response = await _policyRepository.WritePolicyAsync(serviceResource.Identifier, fileStream);
 
             return response?.GetRawResponse()?.Status == (int)HttpStatusCode.Created;
         }


### PR DESCRIPTION
conversion from resourceid to filepath was done twice both in

PolicyRepository.WritePolicyConditionallyAsync
and
ResourceRegistryService.StorePolicy

ending up with two checks for valid characters in filepath for resourceid and adding the filename /resourcepolicy.xml to the end twice.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
