### PR TITLE
Feature/123 authorize scope prefix

### DIFF
--- a/src/Altinn.ResourceRegistry.Core/Constants/AuthzConstants.cs
+++ b/src/Altinn.ResourceRegistry.Core/Constants/AuthzConstants.cs
@@ -35,5 +35,15 @@ namespace Altinn.ResourceRegistry.Core.Constants
         /// Scope for resource registry admin access
         /// </summary>
         public const string SCOPE_RESOURCEREGISTRY_ADMIN = "altinn:resourceregistry/resource.admin";
+
+        /// <summary>
+        /// Claim for scopes from maskinporten token
+        /// </summary>
+        public const string CLAIM_MASKINPORTEN_SCOPE = "scope";
+
+        /// <summary>
+        /// Claim for consumer prefixes from maskinporten token
+        /// </summary>
+        public const string CLAIM_MASKINPORTEN_CONSUMER_PREFIX = "consumer_prefix";
     }
 }

--- a/src/ResourceRegistry/Altinn.ResourceRegistry.csproj
+++ b/src/ResourceRegistry/Altinn.ResourceRegistry.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="JWTCookieAuthentication" Version="3.0.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.21.0" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.2.9" />
     <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.21.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="7.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />

--- a/src/ResourceRegistry/Altinn.ResourceRegistry.csproj
+++ b/src/ResourceRegistry/Altinn.ResourceRegistry.csproj
@@ -15,7 +15,6 @@
     <PackageReference Include="JWTCookieAuthentication" Version="3.0.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.21.0" />
-    <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.2.9" />
     <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.21.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="7.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />

--- a/src/ResourceRegistry/Controllers/ResourceController.cs
+++ b/src/ResourceRegistry/Controllers/ResourceController.cs
@@ -83,7 +83,7 @@ namespace Altinn.ResourceRegistry.Controllers
 
             List<string> scopes = MaskinportenSchemaAuthorizer.GetMaskinportenScopesFromServiceResource(serviceResource);
 
-            if (scopes is { Count: > 0 } && !MaskinportenSchemaAuthorizer.IsAuthorizedDelegationLookupAccess(scopes, HttpContext.User, out List<string> forbiddenScopes))
+            if (scopes is { Count: > 0 } && !MaskinportenSchemaAuthorizer.IsAuthorizedForChangeResourceWithScopes(scopes, HttpContext.User, out List<string> forbiddenScopes))
             {
                 return Unauthorized(MaskinportenSchemaAuthorizer.CreateErrorResponseMissingPrefix(forbiddenScopes));
             }
@@ -141,7 +141,7 @@ namespace Altinn.ResourceRegistry.Controllers
 
             List<string> scopes = MaskinportenSchemaAuthorizer.GetMaskinportenScopesFromServiceResource(serviceResource);
 
-            if (scopes is { Count: > 0 } && !MaskinportenSchemaAuthorizer.IsAuthorizedDelegationLookupAccess(scopes, HttpContext.User, out List<string> forbiddenScopes))
+            if (scopes is { Count: > 0 } && !MaskinportenSchemaAuthorizer.IsAuthorizedForChangeResourceWithScopes(scopes, HttpContext.User, out List<string> forbiddenScopes))
             {
                 return Unauthorized(MaskinportenSchemaAuthorizer.CreateErrorResponseMissingPrefix(forbiddenScopes));
             }

--- a/src/ResourceRegistry/Controllers/ResourceController.cs
+++ b/src/ResourceRegistry/Controllers/ResourceController.cs
@@ -83,12 +83,9 @@ namespace Altinn.ResourceRegistry.Controllers
 
             List<string> scopes = MaskinportenSchemaAuthorizer.GetMaskinportenScopesFromServiceResource(serviceResource);
 
-            if (scopes is { Count: > 0 })
+            if (scopes is { Count: > 0 } && !MaskinportenSchemaAuthorizer.IsAuthorizedDelegationLookupAccess(scopes, HttpContext.User, out List<string> forbiddenScopes))
             {
-                if (!MaskinportenSchemaAuthorizer.IsAuthorizedDelegationLookupAccess(scopes, HttpContext.User, out List<string> forbiddenScopes))
-                {
-                    return Unauthorized(MaskinportenSchemaAuthorizer.CreateErrorResponseMissingPrefix(forbiddenScopes));
-                }
+                return Unauthorized(MaskinportenSchemaAuthorizer.CreateErrorResponseMissingPrefix(forbiddenScopes));
             }
 
             try
@@ -144,12 +141,9 @@ namespace Altinn.ResourceRegistry.Controllers
 
             List<string> scopes = MaskinportenSchemaAuthorizer.GetMaskinportenScopesFromServiceResource(serviceResource);
 
-            if (scopes is { Count: > 0 })
+            if (scopes is { Count: > 0 } && !MaskinportenSchemaAuthorizer.IsAuthorizedDelegationLookupAccess(scopes, HttpContext.User, out List<string> forbiddenScopes))
             {
-                if (!MaskinportenSchemaAuthorizer.IsAuthorizedDelegationLookupAccess(scopes, HttpContext.User, out List<string> forbiddenScopes))
-                {
-                    return Unauthorized(MaskinportenSchemaAuthorizer.CreateErrorResponseMissingPrefix(forbiddenScopes));
-                }
+                return Unauthorized(MaskinportenSchemaAuthorizer.CreateErrorResponseMissingPrefix(forbiddenScopes));
             }
 
             try

--- a/src/ResourceRegistry/Controllers/ResourceController.cs
+++ b/src/ResourceRegistry/Controllers/ResourceController.cs
@@ -1,6 +1,4 @@
-﻿using System.Net;
-using Altinn.ResourceRegistry.Core.Constants;
-using Altinn.ResourceRegistry.Core.Enums;
+﻿using Altinn.ResourceRegistry.Core.Constants;
 using Altinn.ResourceRegistry.Core.Extensions;
 using Altinn.ResourceRegistry.Core.Models;
 using Altinn.ResourceRegistry.Core.Services.Interfaces;

--- a/src/ResourceRegistry/Controllers/ResourceController.cs
+++ b/src/ResourceRegistry/Controllers/ResourceController.cs
@@ -1,4 +1,6 @@
-﻿using Altinn.ResourceRegistry.Core.Constants;
+﻿using System.Net;
+using Altinn.ResourceRegistry.Core.Constants;
+using Altinn.ResourceRegistry.Core.Enums;
 using Altinn.ResourceRegistry.Core.Extensions;
 using Altinn.ResourceRegistry.Core.Models;
 using Altinn.ResourceRegistry.Core.Services.Interfaces;
@@ -81,6 +83,16 @@ namespace Altinn.ResourceRegistry.Controllers
                 return Forbid();
             }
 
+            List<string> scopes = MaskinportenSchemaAuthorizer.GetMaskinportenScopesFromServiceResource(serviceResource);
+
+            if (scopes is { Count: > 0 })
+            {
+                if (!MaskinportenSchemaAuthorizer.IsAuthorizedDelegationLookupAccess(scopes, HttpContext.User, out List<string> forbiddenScopes))
+                {
+                    return Unauthorized(MaskinportenSchemaAuthorizer.CreateErrorResponseMissingPrefix(forbiddenScopes));
+                }
+            }
+
             try
             {
                 await _resourceRegistry.CreateResource(serviceResource);
@@ -130,6 +142,16 @@ namespace Altinn.ResourceRegistry.Controllers
             if (!AuthorizationUtil.HasWriteAccess(serviceResource.HasCompetentAuthority?.Organization, User))
             {
                 return Forbid();
+            }
+
+            List<string> scopes = MaskinportenSchemaAuthorizer.GetMaskinportenScopesFromServiceResource(serviceResource);
+
+            if (scopes is { Count: > 0 })
+            {
+                if (!MaskinportenSchemaAuthorizer.IsAuthorizedDelegationLookupAccess(scopes, HttpContext.User, out List<string> forbiddenScopes))
+                {
+                    return Unauthorized(MaskinportenSchemaAuthorizer.CreateErrorResponseMissingPrefix(forbiddenScopes));
+                }
             }
 
             try

--- a/src/ResourceRegistry/Utils/MaskinportenSchemaAuthorizer.cs
+++ b/src/ResourceRegistry/Utils/MaskinportenSchemaAuthorizer.cs
@@ -1,0 +1,86 @@
+﻿using System.Security.Claims;
+using Altinn.ResourceRegistry.Core.Constants;
+using Altinn.ResourceRegistry.Core.Enums;
+using Altinn.ResourceRegistry.Core.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Altinn.ResourceRegistry.Utils
+{
+    /// <summary>
+    /// Authorization helper for custom authorization for maskinporten schema API operations
+    /// </summary>
+    public static class MaskinportenSchemaAuthorizer
+    {
+        /// <summary>
+        /// Authorization of whether the provided claims is authorized for lookup of delegations of the given scope
+        /// </summary>
+        /// <param name="scope">The scope to authorize for delegation lookup</param>
+        /// <param name="claims">The claims principal of the authenticated organization</param>
+        /// <param name="missingScopes">The scope missing prefix to handle empty list if all ok</param>
+        /// <returns>bool</returns>
+        public static bool IsAuthorizedDelegationLookupAccess(List<string> scope, ClaimsPrincipal claims, out List<string> missingScopes)
+        {
+            if (HasDelegationsAdminScope(claims))
+            {
+                missingScopes = new List<string>();
+                return true;
+            }
+
+            return HasAuthorizedScopePrefixClaim(scope, claims, out missingScopes);
+        }
+
+        /// <summary>
+        /// Creates an error model for missing access to certain scope prefixes
+        /// </summary>
+        /// <param name="forbiddenScopes">the list of scopes with prefixes not valid</param>
+        /// <returns>A complete error model</returns>
+        public static ValidationProblemDetails CreateErrorResponseMissingPrefix(List<string> forbiddenScopes)
+        {
+            var errorContent = forbiddenScopes is {Count: > 0} ? new Dictionary<string, string[]> { { "InvalidPrefix", forbiddenScopes.ToArray() } } : new Dictionary<string, string[]>();
+
+            ValidationProblemDetails error = new ValidationProblemDetails(errorContent)
+            {
+                Title = "Unauthorized",
+                Detail = "Not authorized for creating resource with the listed scopes",
+            };
+
+            return error;
+        }
+
+        /// <summary>
+        /// Returns a list of Maskinporten scopes from a ServiceResource
+        /// </summary>
+        /// <param name="serviceResource">The ServiceResource to fetch scopes from</param>
+        /// <returns>null if the ServiceResource has no ResourceReferences, an empty list if the list contains no Maskinporten scopes or a list of the existing scopes</returns>
+        public static List<string> GetMaskinportenScopesFromServiceResource(ServiceResource serviceResource)
+        {
+            return serviceResource.ResourceReferences?.FindAll(r => r.ReferenceType == ReferenceType.MaskinportenScope && r.Reference != null).Select(r => r.Reference).ToList();
+        }
+
+        private static bool HasDelegationsAdminScope(ClaimsPrincipal claims)
+        {
+            return HasScope(claims, AuthzConstants.SCOPE_RESOURCEREGISTRY_ADMIN);
+        }
+
+        private static bool HasScope(ClaimsPrincipal claims, string scope)
+        {
+            Claim c = claims.Claims.FirstOrDefault(x => x.Type == AuthzConstants.CLAIM_MASKINPORTEN_SCOPE);
+            if (c == null)
+            {
+                return false;
+            }
+
+            string[] scopes = c.Value.Split(' ');
+
+            return scopes.Contains(scope);
+        }
+
+        private static bool HasAuthorizedScopePrefixClaim(List<string> scopesToAuthorize, ClaimsPrincipal claims, out List<string> missingScopes)
+        {
+            List<string> prefixes = claims.Claims.Where(x => x.Type == AuthzConstants.CLAIM_MASKINPORTEN_CONSUMER_PREFIX).Select(v => v.Value).ToList();
+            missingScopes = scopesToAuthorize.FindAll(scope => !prefixes.Any(prefix => scope.StartsWith(prefix + ':')));
+
+            return missingScopes.Count == 0;
+        }
+    }
+}

--- a/src/ResourceRegistry/Utils/MaskinportenSchemaAuthorizer.cs
+++ b/src/ResourceRegistry/Utils/MaskinportenSchemaAuthorizer.cs
@@ -36,7 +36,7 @@ namespace Altinn.ResourceRegistry.Utils
         /// <returns>A complete error model</returns>
         public static ValidationProblemDetails CreateErrorResponseMissingPrefix(List<string> forbiddenScopes)
         {
-            var errorContent = forbiddenScopes is {Count: > 0} ? new Dictionary<string, string[]> { { "InvalidPrefix", forbiddenScopes.ToArray() } } : new Dictionary<string, string[]>();
+            var errorContent = forbiddenScopes is { Count: > 0 } ? new Dictionary<string, string[]> { { "InvalidPrefix", forbiddenScopes.ToArray() } } : new Dictionary<string, string[]>();
 
             ValidationProblemDetails error = new ValidationProblemDetails(errorContent)
             {

--- a/src/ResourceRegistry/Utils/MaskinportenSchemaAuthorizer.cs
+++ b/src/ResourceRegistry/Utils/MaskinportenSchemaAuthorizer.cs
@@ -18,7 +18,7 @@ namespace Altinn.ResourceRegistry.Utils
         /// <param name="claims">The claims principal of the authenticated organization</param>
         /// <param name="missingScopes">The scope missing prefix to handle empty list if all ok</param>
         /// <returns>bool</returns>
-        public static bool IsAuthorizedDelegationLookupAccess(List<string> scope, ClaimsPrincipal claims, out List<string> missingScopes)
+        public static bool IsAuthorizedForChangeResourceWithScopes(List<string> scope, ClaimsPrincipal claims, out List<string> missingScopes)
         {
             if (HasDelegationsAdminScope(claims))
             {

--- a/test/ResourceRegistryTest/ResourceControllerTest.cs
+++ b/test/ResourceRegistryTest/ResourceControllerTest.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using Altinn.ResourceRegistry.Tests.Utils;
 using Microsoft.AspNetCore.Mvc;
 using Altinn.ResourceRegistry.Controllers;
+using Altinn.ResourceRegistry.Core.Enums;
 using Altinn.ResourceRegistry.Core.Models;
 using Xunit;
 
@@ -121,6 +122,470 @@ namespace Altinn.ResourceRegistry.Tests
             Assert.Equal(8, errordetails.Errors.Count);
         }
 
+        [Fact]
+        public async Task CreateResource_WithAdminScope()
+        {
+            string token = PrincipalUtil.GetOrgToken("skd", "974761076", "altinn:resourceregistry/resource.admin");
+            _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+            ServiceResource resource = new ServiceResource()
+            {
+                Identifier = "superdupertjenestene",
+                Title = new Dictionary<string, string>(),
+                Sector = new List<string>(),
+                Status = "Active",
+                Homepage = "www.altinn.no",
+                IsPartOf = "Altinn",
+                Keywords = new List<Keyword>(),
+                Description = new Dictionary<string, string>(),
+                RightDescription = new Dictionary<string, string>(),
+                HasCompetentAuthority = new Altinn.ResourceRegistry.Core.Models.CompetentAuthority()
+                {
+                    Organization = "974761076",
+                    Orgcode = "skd",
+                },
+                ResourceReferences = new List<ResourceReference>
+                {
+                    new()
+                    {
+                        ReferenceSource = ReferenceSource.Altinn2,
+                        ReferenceType = ReferenceType.MaskinportenScope,
+                        Reference = "altinn:TestScope"
+                    },
+                    new()
+                    {
+                        ReferenceSource = ReferenceSource.Altinn2,
+                        ReferenceType = ReferenceType.MaskinportenScope,
+                        Reference = "digdir:TestScope"
+                    },
+                    new()
+                    {
+                        ReferenceSource = ReferenceSource.Altinn2,
+                        ReferenceType = ReferenceType.MaskinportenScope,
+                        Reference = "difi:TestScope"
+                    },
+                    new()
+                    {
+                        ReferenceSource = ReferenceSource.Altinn2,
+                        ReferenceType = ReferenceType.MaskinportenScope,
+                        Reference = "krr:TestScope"
+                    },
+                    new()
+                    {
+                        ReferenceSource = ReferenceSource.Altinn2,
+                        ReferenceType = ReferenceType.MaskinportenScope,
+                        Reference = "test:TestScope"
+                    },
+                }
+
+            };
+            resource.IsComplete = true;
+
+            string requestUri = "resourceregistry/api/v1/Resource/";
+
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, requestUri)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(resource), Encoding.UTF8, "application/json")
+            };
+
+            httpRequestMessage.Headers.Add("Accept", "application/json");
+            httpRequestMessage.Headers.Add("ContentType", "application/json");
+
+            HttpResponseMessage response = await _client.SendAsync(httpRequestMessage);
+
+            Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task CreateResource_WithValidPrefix()
+        {
+            string[] prefixes = { "altinn", "digdir", "difi", "krr", "test", "digdirintern", "idporten", "digitalpostinnbygger", "minid", "move", "difitest"};
+            string token = PrincipalUtil.GetOrgToken("skd", "974761076", "altinn:resourceregistry/resource.write", prefixes);
+            _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+            ServiceResource resource = new ServiceResource()
+            {
+                Identifier = "superdupertjenestene",
+                Title = new Dictionary<string, string>(),
+                Sector = new List<string>(),
+                Status = "Active",
+                Homepage = "www.altinn.no",
+                IsPartOf = "Altinn",
+                Keywords = new List<Keyword>(),
+                Description = new Dictionary<string, string>(),
+                RightDescription = new Dictionary<string, string>(),
+                HasCompetentAuthority = new Altinn.ResourceRegistry.Core.Models.CompetentAuthority()
+                {
+                    Organization = "974761076",
+                    Orgcode = "skd",
+                },
+                ResourceReferences = new List<ResourceReference>
+                {
+                    new()
+                    {
+                        ReferenceSource = ReferenceSource.Altinn2,
+                        ReferenceType = ReferenceType.MaskinportenScope,
+                        Reference = "altinn:TestScope"
+                    },
+                    new()
+                    {
+                        ReferenceSource = ReferenceSource.Altinn2,
+                        ReferenceType = ReferenceType.MaskinportenScope,
+                        Reference = "digdir:TestScope"
+                    },
+                    new()
+                    {
+                        ReferenceSource = ReferenceSource.Altinn2,
+                        ReferenceType = ReferenceType.MaskinportenScope,
+                        Reference = "difi:TestScope"
+                    },
+                    new()
+                    {
+                        ReferenceSource = ReferenceSource.Altinn2,
+                        ReferenceType = ReferenceType.MaskinportenScope,
+                        Reference = "krr:TestScope"
+                    },
+                    new()
+                    {
+                        ReferenceSource = ReferenceSource.Altinn2,
+                        ReferenceType = ReferenceType.MaskinportenScope,
+                        Reference = "test:TestScope"
+                    },
+                }
+
+            };
+            resource.IsComplete = true;
+
+            string requestUri = "resourceregistry/api/v1/Resource/";
+
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, requestUri)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(resource), Encoding.UTF8, "application/json")
+            };
+
+            httpRequestMessage.Headers.Add("Accept", "application/json");
+            httpRequestMessage.Headers.Add("ContentType", "application/json");
+
+            HttpResponseMessage response = await _client.SendAsync(httpRequestMessage);
+
+            Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task CreateResource_WithInvalidPrefix()
+        {
+            string[] prefixes = {"altinn", "digdir"};
+            string token = PrincipalUtil.GetOrgToken("skd", "974761076", "altinn:resourceregistry/resource.write", prefixes);
+            _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+            ServiceResource resource = new ServiceResource()
+            {
+                Identifier = "superdupertjenestene",
+                Title = new Dictionary<string, string>(),
+                Sector = new List<string>(),
+                Status = "Active",
+                Homepage = "www.altinn.no",
+                IsPartOf  = "Altinn",
+                Keywords = new List<Keyword>(),
+                Description = new Dictionary<string, string>(),
+                RightDescription = new Dictionary<string, string>(),
+                HasCompetentAuthority = new Altinn.ResourceRegistry.Core.Models.CompetentAuthority()
+                {
+                    Organization = "974761076",
+                    Orgcode = "skd",
+                },
+                ResourceReferences = new List<ResourceReference>
+                {
+                    new()
+                    {
+                        ReferenceSource = ReferenceSource.Altinn2,
+                        ReferenceType = ReferenceType.MaskinportenScope,
+                        Reference = "altinn:TestScope"
+                    },
+                    new()
+                    {
+                        ReferenceSource = ReferenceSource.Altinn2,
+                        ReferenceType = ReferenceType.MaskinportenScope,
+                        Reference = "digdir:TestScope"
+                    },
+                    new()
+                    {
+                        ReferenceSource = ReferenceSource.Altinn2,
+                        ReferenceType = ReferenceType.MaskinportenScope,
+                        Reference = "difi:TestScope"
+                    },
+                    new()
+                    {
+                        ReferenceSource = ReferenceSource.Altinn2,
+                        ReferenceType = ReferenceType.MaskinportenScope,
+                        Reference = "krr:TestScope"
+                    },
+                    new()
+                    {
+                        ReferenceSource = ReferenceSource.Altinn2,
+                        ReferenceType = ReferenceType.MaskinportenScope,
+                        Reference = "test:TestScope"
+                    },
+                }
+
+            };
+            resource.IsComplete = true;
+
+            string requestUri = "resourceregistry/api/v1/Resource/";
+
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, requestUri)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(resource), Encoding.UTF8, "application/json")
+            };
+
+            httpRequestMessage.Headers.Add("Accept", "application/json");
+            httpRequestMessage.Headers.Add("ContentType", "application/json");
+
+            HttpResponseMessage response = await _client.SendAsync(httpRequestMessage);
+
+            string responseContent = await response.Content.ReadAsStringAsync();
+
+            ValidationProblemDetails? errordetails = JsonSerializer.Deserialize<ValidationProblemDetails>(responseContent, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+            Assert.NotNull(errordetails);
+
+            Assert.Equal(1, errordetails.Errors.Count);
+            Assert.Equal(3, errordetails.Errors["InvalidPrefix"].Length);
+        }
+
+        [Fact]
+        public async Task UpdateResource_WithAdminScope()
+        {
+            string token = PrincipalUtil.GetOrgToken("skd", "974761076", "altinn:resourceregistry/resource.admin");
+            _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+            ServiceResource resource = new ServiceResource()
+            {
+                Identifier = "altinn_access_management",
+                Title = new Dictionary<string, string>(),
+                Sector = new List<string>(),
+                Status = "Active",
+                Homepage = "www.altinn.no",
+                IsPartOf = "Altinn",
+                Keywords = new List<Keyword>(),
+                Description = new Dictionary<string, string>(),
+                RightDescription = new Dictionary<string, string>(),
+                HasCompetentAuthority = new Altinn.ResourceRegistry.Core.Models.CompetentAuthority()
+                {
+                    Organization = "974761076",
+                    Orgcode = "skd",
+                },
+                ResourceReferences = new List<ResourceReference>
+                {
+                    new()
+                    {
+                        ReferenceSource = ReferenceSource.Altinn2,
+                        ReferenceType = ReferenceType.MaskinportenScope,
+                        Reference = "altinn:TestScope"
+                    },
+                    new()
+                    {
+                        ReferenceSource = ReferenceSource.Altinn2,
+                        ReferenceType = ReferenceType.MaskinportenScope,
+                        Reference = "digdir:TestScope"
+                    },
+                    new()
+                    {
+                        ReferenceSource = ReferenceSource.Altinn2,
+                        ReferenceType = ReferenceType.MaskinportenScope,
+                        Reference = "difi:TestScope"
+                    },
+                    new()
+                    {
+                        ReferenceSource = ReferenceSource.Altinn2,
+                        ReferenceType = ReferenceType.MaskinportenScope,
+                        Reference = "krr:TestScope"
+                    },
+                    new()
+                    {
+                        ReferenceSource = ReferenceSource.Altinn2,
+                        ReferenceType = ReferenceType.MaskinportenScope,
+                        Reference = "test:TestScope"
+                    },
+                }
+
+            };
+            resource.IsComplete = true;
+
+            string requestUri = $"resourceregistry/api/v1/Resource/{resource.Identifier}";
+
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Put, requestUri)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(resource), Encoding.UTF8, "application/json")
+            };
+
+            httpRequestMessage.Headers.Add("Accept", "application/json");
+            httpRequestMessage.Headers.Add("ContentType", "application/json");
+
+            HttpResponseMessage response = await _client.SendAsync(httpRequestMessage);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task UpdateResource_WithValidPrefix()
+        {
+            string[] prefixes = { "altinn", "digdir", "difi", "krr", "test", "digdirintern", "idporten", "digitalpostinnbygger", "minid", "move", "difitest" };
+            string token = PrincipalUtil.GetOrgToken("skd", "974761076", "altinn:resourceregistry/resource.write", prefixes);
+            _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+            ServiceResource resource = new ServiceResource()
+            {
+                Identifier = "altinn_access_management",
+                Title = new Dictionary<string, string>(),
+                Sector = new List<string>(),
+                Status = "Active",
+                Homepage = "www.altinn.no",
+                IsPartOf = "Altinn",
+                Keywords = new List<Keyword>(),
+                Description = new Dictionary<string, string>(),
+                RightDescription = new Dictionary<string, string>(),
+                HasCompetentAuthority = new Altinn.ResourceRegistry.Core.Models.CompetentAuthority()
+                {
+                    Organization = "974761076",
+                    Orgcode = "skd",
+                },
+                ResourceReferences = new List<ResourceReference>
+                {
+                    new()
+                    {
+                        ReferenceSource = ReferenceSource.Altinn2,
+                        ReferenceType = ReferenceType.MaskinportenScope,
+                        Reference = "altinn:TestScope"
+                    },
+                    new()
+                    {
+                        ReferenceSource = ReferenceSource.Altinn2,
+                        ReferenceType = ReferenceType.MaskinportenScope,
+                        Reference = "digdir:TestScope"
+                    },
+                    new()
+                    {
+                        ReferenceSource = ReferenceSource.Altinn2,
+                        ReferenceType = ReferenceType.MaskinportenScope,
+                        Reference = "difi:TestScope"
+                    },
+                    new()
+                    {
+                        ReferenceSource = ReferenceSource.Altinn2,
+                        ReferenceType = ReferenceType.MaskinportenScope,
+                        Reference = "krr:TestScope"
+                    },
+                    new()
+                    {
+                        ReferenceSource = ReferenceSource.Altinn2,
+                        ReferenceType = ReferenceType.MaskinportenScope,
+                        Reference = "test:TestScope"
+                    },
+                }
+
+            };
+            resource.IsComplete = true;
+
+            string requestUri = $"resourceregistry/api/v1/Resource/{resource.Identifier}";
+
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Put, requestUri)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(resource), Encoding.UTF8, "application/json")
+            };
+
+            httpRequestMessage.Headers.Add("Accept", "application/json");
+            httpRequestMessage.Headers.Add("ContentType", "application/json");
+
+            HttpResponseMessage response = await _client.SendAsync(httpRequestMessage);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task UpdateResource_WithInvalidPrefix()
+        {
+            string[] prefixes = { "altinn", "digdir" };
+            string token = PrincipalUtil.GetOrgToken("skd", "974761076", "altinn:resourceregistry/resource.write", prefixes);
+            _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+            ServiceResource resource = new ServiceResource()
+            {
+                Identifier = "altinn_access_management",
+                Title = new Dictionary<string, string>(),
+                Sector = new List<string>(),
+                Status = "Active",
+                Homepage = "www.altinn.no",
+                IsPartOf = "Altinn",
+                Keywords = new List<Keyword>(),
+                Description = new Dictionary<string, string>(),
+                RightDescription = new Dictionary<string, string>(),
+                HasCompetentAuthority = new Altinn.ResourceRegistry.Core.Models.CompetentAuthority()
+                {
+                    Organization = "974761076",
+                    Orgcode = "skd",
+                },
+                ResourceReferences = new List<ResourceReference>
+                {
+                    new()
+                    {
+                        ReferenceSource = ReferenceSource.Altinn2,
+                        ReferenceType = ReferenceType.MaskinportenScope,
+                        Reference = "altinn:TestScope"
+                    },
+                    new()
+                    {
+                        ReferenceSource = ReferenceSource.Altinn2,
+                        ReferenceType = ReferenceType.MaskinportenScope,
+                        Reference = "digdir:TestScope"
+                    },
+                    new()
+                    {
+                        ReferenceSource = ReferenceSource.Altinn2,
+                        ReferenceType = ReferenceType.MaskinportenScope,
+                        Reference = "difi:TestScope"
+                    },
+                    new()
+                    {
+                        ReferenceSource = ReferenceSource.Altinn2,
+                        ReferenceType = ReferenceType.MaskinportenScope,
+                        Reference = "krr:TestScope"
+                    },
+                    new()
+                    {
+                        ReferenceSource = ReferenceSource.Altinn2,
+                        ReferenceType = ReferenceType.MaskinportenScope,
+                        Reference = "test:TestScope"
+                    },
+                }
+
+            };
+            resource.IsComplete = true;
+
+            string requestUri = $"resourceregistry/api/v1/Resource/{resource.Identifier}";
+
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Put, requestUri)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(resource), Encoding.UTF8, "application/json")
+            };
+
+            httpRequestMessage.Headers.Add("Accept", "application/json");
+            httpRequestMessage.Headers.Add("ContentType", "application/json");
+
+            HttpResponseMessage response = await _client.SendAsync(httpRequestMessage);
+
+            string responseContent = await response.Content.ReadAsStringAsync();
+
+            ValidationProblemDetails? errordetails = JsonSerializer.Deserialize<ValidationProblemDetails>(responseContent, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+            Assert.NotNull(errordetails);
+
+            Assert.Equal(1, errordetails.Errors.Count);
+            Assert.Equal(3, errordetails.Errors["InvalidPrefix"].Length);
+        }
+        
         [Fact]
         public async Task SetResourcePolicy_OK()
         {

--- a/test/ResourceRegistryTest/Utils/PrincipalUtil.cs
+++ b/test/ResourceRegistryTest/Utils/PrincipalUtil.cs
@@ -60,7 +60,7 @@ namespace Altinn.ResourceRegistry.Tests.Utils
             return token;
         }
 
-        public static ClaimsPrincipal GetClaimsPrincipal(string org, string orgNumber, string scope = null, string[]? prefixes = null)
+        public static ClaimsPrincipal GetClaimsPrincipal(string org, string orgNumber, string? scope = null, string[]? prefixes = null)
         {
             string issuer = "www.altinn.no";
 
@@ -94,7 +94,7 @@ namespace Altinn.ResourceRegistry.Tests.Utils
             return new ClaimsPrincipal(identity);
         }
 
-        public static string GetOrgToken(string org, string orgNumber = "991825827", string scope = null, string[]? prefixes = null)
+        public static string GetOrgToken(string org, string orgNumber = "991825827", string? scope = null, string[]? prefixes = null)
         {
             ClaimsPrincipal principal = GetClaimsPrincipal(org, orgNumber, scope, prefixes);
 

--- a/test/ResourceRegistryTest/Utils/PrincipalUtil.cs
+++ b/test/ResourceRegistryTest/Utils/PrincipalUtil.cs
@@ -60,7 +60,7 @@ namespace Altinn.ResourceRegistry.Tests.Utils
             return token;
         }
 
-        public static ClaimsPrincipal GetClaimsPrincipal(string org, string orgNumber, string scope = null)
+        public static ClaimsPrincipal GetClaimsPrincipal(string org, string orgNumber, string scope = null, string[]? prefixes = null)
         {
             string issuer = "www.altinn.no";
 
@@ -72,7 +72,15 @@ namespace Altinn.ResourceRegistry.Tests.Utils
 
             if (scope != null)
             {
-                claims.Add(new Claim("urn:altinn:scope", scope, ClaimValueTypes.String, "maskinporten"));
+                claims.Add(new Claim("scope", scope, ClaimValueTypes.String, "maskinporten"));
+            }
+
+            if (prefixes is {Length: > 0})
+            {
+                foreach (string prefix in prefixes)
+                {
+                    claims.Add(new Claim("consumer_prefix", prefix, ClaimValueTypes.String,"maskinporten"));
+                }
             }
 
             claims.Add(new Claim(AltinnCoreClaimTypes.OrgNumber, orgNumber.ToString(), ClaimValueTypes.Integer32, issuer));
@@ -86,9 +94,9 @@ namespace Altinn.ResourceRegistry.Tests.Utils
             return new ClaimsPrincipal(identity);
         }
 
-        public static string GetOrgToken(string org, string orgNumber = "991825827", string scope = null)
+        public static string GetOrgToken(string org, string orgNumber = "991825827", string scope = null, string[]? prefixes = null)
         {
-            ClaimsPrincipal principal = GetClaimsPrincipal(org, orgNumber, scope);
+            ClaimsPrincipal principal = GetClaimsPrincipal(org, orgNumber, scope, prefixes);
 
             string token = JwtTokenMock.GenerateToken(principal, new TimeSpan(1, 1, 1));
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This code checks all Create and update calls for Maskinporten scopes and verifies that the caller has access to all prefixes he adds to the Resource.

## Related Issue(s)
- Fixes #123

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
