### PR TITLE
Changed timestamp data type from timetz to timestamptz to add date in…

### DIFF
--- a/src/Altinn.ResourceRegistry.Persistence/Migration/v0.00-resource-registry/01-setup-tables.sql
+++ b/src/Altinn.ResourceRegistry.Persistence/Migration/v0.00-resource-registry/01-setup-tables.sql
@@ -1,12 +1,14 @@
 -- Schema: resourceregistry
 CREATE SCHEMA IF NOT EXISTS resourceregistry;
 
+DROP TABLE IF EXISTS resourceregistry.resources
+
 -- Table: resourceregistry.resources
-CREATE TABLE IF NOT EXISTS resourceregistry.resources
+CREATE TABLE  resourceregistry.resources
 (
     identifier text COLLATE pg_catalog."default" NOT NULL,
-    created time with time zone NOT NULL,
-    modified time with time zone,
+    created timestamp with time zone NOT NULL,
+    modified timestamp with time zone,
     serviceresourcejson jsonb,
     CONSTRAINT resourceregistry_pkey PRIMARY KEY (identifier)
 )
@@ -14,7 +16,7 @@ TABLESPACE pg_default;
 
 -- Enum: resourceregistry.resourcetype
 DO $$ BEGIN
-    CREATE TYPE resourceregistry.resourcetype AS ENUM ('default', 'systemresource', 'altinn2', 'altinn3', 'apischema', 'api');
+    CREATE TYPE resourceregistry.resourcetype AS ENUM ('default', 'systemresource', 'maskinportenschema');
 EXCEPTION
     WHEN duplicate_object THEN null;
 END $$;

--- a/src/Altinn.ResourceRegistry.Persistence/Migration/v0.00-resource-registry/01-setup-tables.sql
+++ b/src/Altinn.ResourceRegistry.Persistence/Migration/v0.00-resource-registry/01-setup-tables.sql
@@ -1,7 +1,12 @@
 -- Schema: resourceregistry
 CREATE SCHEMA IF NOT EXISTS resourceregistry;
 
-DROP TABLE IF EXISTS resourceregistry.resources
+DROP FUNCTION IF EXISTS resourceregistry.create_resource(text, jsonb);
+DROP FUNCTION IF EXISTS resourceregistry.delete_resource(text);
+DROP FUNCTION IF EXISTS resourceregistry.get_resource(character varying);
+DROP FUNCTION IF EXISTS resourceregistry.search_for_resource(text, text, text, resourceregistry.resourcetype, text, boolean);
+DROP FUNCTION IF EXISTS resourceregistry.update_resource(text, jsonb);
+DROP TABLE IF EXISTS resourceregistry.resources;
 
 -- Table: resourceregistry.resources
 CREATE TABLE  resourceregistry.resources


### PR DESCRIPTION
…fo not only clock info. Nobody is interested in a resource created 14;38 but not knowing witch date it was. Will delete the notification that the script is run so it wil actualy run the next time code is deployed.

Also changed the resource type to reflect the actual types in the enum in code. Also fixed this directly in AT21-AT24.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
