### PR TITLE
Changed the response for when resource already exists to 409 Conflict.

### DIFF
--- a/src/ResourceRegistry/Controllers/ResourceController.cs
+++ b/src/ResourceRegistry/Controllers/ResourceController.cs
@@ -121,7 +121,7 @@ namespace Altinn.ResourceRegistry.Controllers
             catch (Exception e)
             {
                 return e.Message.Contains("duplicate key value violates unique constraint")
-                    ? BadRequest($"The Resource already exist: {serviceResource.Identifier}")
+                    ? Conflict($"The Resource already exist: {serviceResource.Identifier}")
                     : StatusCode(500, e.Message);
             }
         }


### PR DESCRIPTION
## Description
Changed the response for when resource already exists to 409 Conflict.
This makes the altinn-studio designer able to see if the cause of the error was conflict or bad request in general.

## Related Issue(s)
- altinn-studio: #10337

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
