### PR TITLE
chore: cleanup async and db access

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+﻿[*.cs]
+
+# VSTHRD200: Use "Async" suffix for async methods
+dotnet_diagnostic.VSTHRD200.severity = none

--- a/ResourceRegistry.sln
+++ b/ResourceRegistry.sln
@@ -3,6 +3,15 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31912.275
 MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{F8341BDC-AFD6-4940-BBCF-3479AB059851}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{1C641B54-56A0-476C-A207-23E4C326BC17}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{BE70AAFA-E0AB-4EEC-897E-4B311939CA9A}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Altinn.ResourceRegistry", "src\ResourceRegistry\Altinn.ResourceRegistry.csproj", "{1CEF3493-0F24-46E8-9BC0-63A213FE6C55}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Altinn.ResourceRegistry.Tests", "test\ResourceRegistryTest\Altinn.ResourceRegistry.Tests.csproj", "{720B753A-28B3-46E1-8C69-7A1EED0C94E5}"
@@ -12,11 +21,6 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Altinn.ResourceRegistry.Persistence", "src\Altinn.ResourceRegistry.Persistence\Altinn.ResourceRegistry.Persistence.csproj", "{1AE36D08-7DE9-41A7-8306-0696F3BF2AC6}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Altinn.ResourceRegistry.Integration", "src\Altinn.ResourceRegistry.Integration\Altinn.ResourceRegistry.Integration.csproj", "{28B0545F-050F-41C2-AA02-214C96A01AD0}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{F8341BDC-AFD6-4940-BBCF-3479AB059851}"
-	ProjectSection(SolutionItems) = preProject
-		.editorconfig = .editorconfig
-	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -47,6 +51,13 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{1CEF3493-0F24-46E8-9BC0-63A213FE6C55} = {1C641B54-56A0-476C-A207-23E4C326BC17}
+		{720B753A-28B3-46E1-8C69-7A1EED0C94E5} = {BE70AAFA-E0AB-4EEC-897E-4B311939CA9A}
+		{2445DE2C-CBD4-4E30-8E35-711CA93362E8} = {1C641B54-56A0-476C-A207-23E4C326BC17}
+		{1AE36D08-7DE9-41A7-8306-0696F3BF2AC6} = {1C641B54-56A0-476C-A207-23E4C326BC17}
+		{28B0545F-050F-41C2-AA02-214C96A01AD0} = {1C641B54-56A0-476C-A207-23E4C326BC17}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {9933806A-F446-4097-BA19-B947F2240FF2}

--- a/ResourceRegistry.sln
+++ b/ResourceRegistry.sln
@@ -11,7 +11,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Altinn.ResourceRegistry.Cor
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Altinn.ResourceRegistry.Persistence", "src\Altinn.ResourceRegistry.Persistence\Altinn.ResourceRegistry.Persistence.csproj", "{1AE36D08-7DE9-41A7-8306-0696F3BF2AC6}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Altinn.ResourceRegistry.Integration", "src\Altinn.ResourceRegistry.Integration\Altinn.ResourceRegistry.Integration.csproj", "{28B0545F-050F-41C2-AA02-214C96A01AD0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Altinn.ResourceRegistry.Integration", "src\Altinn.ResourceRegistry.Integration\Altinn.ResourceRegistry.Integration.csproj", "{28B0545F-050F-41C2-AA02-214C96A01AD0}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{F8341BDC-AFD6-4940-BBCF-3479AB059851}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Altinn.ResourceRegistry.Core/Altinn.ResourceRegistry.Core.csproj
+++ b/src/Altinn.ResourceRegistry.Core/Altinn.ResourceRegistry.Core.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Azure.Storage.Blobs" Version="12.19.1" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
+    <PackageReference Include="Nerdbank.Streams" Version="2.10.72" />
     <PackageReference Include="Npgsql" Version="7.0.6" />
     
     

--- a/src/Altinn.ResourceRegistry.Core/Clients/AccessManagementClient.cs
+++ b/src/Altinn.ResourceRegistry.Core/Clients/AccessManagementClient.cs
@@ -50,7 +50,7 @@ namespace Altinn.ResourceRegistry.Core.Clients
         /// </summary>
         /// <param name="resources">A list of resources to add to Access Management</param>
         /// <returns>A HTTP response message</returns>
-        public async Task<HttpResponseMessage> AddResourceToAccessManagement(List<AccessManagementResource> resources)
+        public async Task<HttpResponseMessage> AddResourceToAccessManagement(List<AccessManagementResource> resources, CancellationToken cancellationToken = default)
         {
             using var request = new HttpRequestMessage(HttpMethod.Post, AccessManagementEndpoint)
             {
@@ -68,7 +68,7 @@ namespace Altinn.ResourceRegistry.Core.Clients
                     await request.Content.ReadAsStringAsync());
             }
 
-            return await Client.SendAsync(request);
+            return await Client.SendAsync(request, cancellationToken);
         }
     }
 }

--- a/src/Altinn.ResourceRegistry.Core/Clients/AccessManagementClient.cs
+++ b/src/Altinn.ResourceRegistry.Core/Clients/AccessManagementClient.cs
@@ -49,6 +49,7 @@ namespace Altinn.ResourceRegistry.Core.Clients
         /// Posts a list of delegation events to the Altinn Bridge API endpoint
         /// </summary>
         /// <param name="resources">A list of resources to add to Access Management</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
         /// <returns>A HTTP response message</returns>
         public async Task<HttpResponseMessage> AddResourceToAccessManagement(List<AccessManagementResource> resources, CancellationToken cancellationToken = default)
         {

--- a/src/Altinn.ResourceRegistry.Core/Clients/AccessManagementClient.cs
+++ b/src/Altinn.ResourceRegistry.Core/Clients/AccessManagementClient.cs
@@ -46,7 +46,7 @@ namespace Altinn.ResourceRegistry.Core.Clients
         }
 
         /// <summary>
-        /// Posts a list of delegation events to the Altinn Bridge API endpoint
+        /// Posts a list of delegation events to the Altinn Access Management API endpoint
         /// </summary>
         /// <param name="resources">A list of resources to add to Access Management</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
@@ -59,15 +59,6 @@ namespace Altinn.ResourceRegistry.Core.Clients
             };
             
             request.Headers.Add(_settings.AccessTokenHeaderId, _accessTokenGenerator.GenerateAccessToken(_settings.AccessTokenIssuer, _settings.AccessTokenApp));
-
-            if (_logger.IsEnabled(LogLevel.Debug))
-            {
-                _logger.LogDebug(
-                    "AccessManagementClient posting resource list to {url} with token {token} and body {body}",
-                    request.RequestUri,
-                    request.Headers.GetValues(_settings.AccessTokenHeaderId).FirstOrDefault(),
-                    await request.Content.ReadAsStringAsync());
-            }
 
             return await Client.SendAsync(request, cancellationToken);
         }

--- a/src/Altinn.ResourceRegistry.Core/Clients/Interfaces/IAccessManagementClient.cs
+++ b/src/Altinn.ResourceRegistry.Core/Clients/Interfaces/IAccessManagementClient.cs
@@ -11,7 +11,8 @@ namespace Altinn.ResourceRegistry.Core.Clients.Interfaces
         /// Adds a resource to Access Management
         /// </summary>
         /// <param name="resources">input to store in Accerss Management</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
         /// <returns>The http response</returns>
-        Task<HttpResponseMessage> AddResourceToAccessManagement(List<AccessManagementResource> resources);
+        Task<HttpResponseMessage> AddResourceToAccessManagement(List<AccessManagementResource> resources, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Altinn.ResourceRegistry.Core/Extensions/StreamExtensions.cs
+++ b/src/Altinn.ResourceRegistry.Core/Extensions/StreamExtensions.cs
@@ -1,0 +1,73 @@
+﻿using System.Buffers;
+using Nerdbank.Streams;
+
+namespace Altinn.ResourceRegistry.Core.Extensions;
+
+/// <summary>
+/// Extension methods for working with streams.
+/// </summary>
+public static class StreamExtensions
+{
+    // Copied from System.Io.Stream
+    private const int DefaultCopyBufferSize = 81920;
+
+    /// <summary>
+    /// Copy the contents of a stream into a <see cref="IBufferWriter{T}"/>.
+    /// </summary>
+    /// <param name="stream">The <see cref="Stream"/> to copy.</param>
+    /// <param name="bufferWriter">The destination <see cref="IBufferWriter{T}"/>.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+    /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+    public static Task CopyToAsync(
+        this Stream stream,
+        IBufferWriter<byte> bufferWriter,
+        CancellationToken cancellationToken = default)
+        => stream.CopyToAsync(bufferWriter, DefaultCopyBufferSize, cancellationToken);
+
+    /// <summary>
+    /// Copy the contents of a stream into a <see cref="IBufferWriter{T}"/>.
+    /// </summary>
+    /// <param name="stream">The <see cref="Stream"/> to copy.</param>
+    /// <param name="bufferWriter">The destination <see cref="IBufferWriter{T}"/>.</param>
+    /// <param name="bufferSize">The buffer size to use for each copy iteration.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+    /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+    public static async Task CopyToAsync(
+        this Stream stream, 
+        IBufferWriter<byte> bufferWriter, 
+        int bufferSize,
+        CancellationToken cancellationToken = default) 
+    {
+        if (!stream.CanRead) 
+        {
+            throw new ArgumentException(nameof(stream), "Stream is not readable");
+        } 
+
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var buffer = bufferWriter.GetMemory(bufferSize);
+            var read = await stream.ReadAtLeastAsync(buffer, buffer.Length, throwOnEndOfStream: false, cancellationToken);
+            bufferWriter.Advance(read);
+
+            if (read < buffer.Length)
+            {
+                // We've reached the end of the stream.
+                return;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Read stream into a <see cref="Sequence{T}"/>. This will rent buffers from the shared dotnet memorypool.
+    /// </summary>
+    /// <param name="stream">The <see cref="Stream"/> to copy.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+    /// <returns>A <see cref="Sequence{T}"/> containing the data read from <paramref name="stream"/>.</returns>
+    public static async Task<Sequence<byte>> ReadToSequenceAsync(this Stream stream, CancellationToken cancellationToken = default)
+    {
+        var builder = new Sequence<byte>(MemoryPool<byte>.Shared);
+        await stream.CopyToAsync(builder, cancellationToken);
+        return builder;
+    }
+}

--- a/src/Altinn.ResourceRegistry.Core/Extensions/StreamExtensions.cs
+++ b/src/Altinn.ResourceRegistry.Core/Extensions/StreamExtensions.cs
@@ -38,9 +38,11 @@ public static class StreamExtensions
         int bufferSize,
         CancellationToken cancellationToken = default) 
     {
+        ArgumentNullException.ThrowIfNull(stream);
+
         if (!stream.CanRead) 
         {
-            throw new ArgumentException(nameof(stream), "Stream is not readable");
+            throw new ArgumentException("Stream is not readable", nameof(stream));
         } 
 
         while (true)

--- a/src/Altinn.ResourceRegistry.Core/Helpers/PolicyHelper.cs
+++ b/src/Altinn.ResourceRegistry.Core/Helpers/PolicyHelper.cs
@@ -78,6 +78,7 @@ namespace Altinn.ResourceRegistry.Core.Helpers
         /// <returns>XacmlPolicy</returns>
         public static XacmlPolicy ParsePolicy(Stream stream)
         {
+            // TODO: This is reading a stream synchronously, which could be problematic.
             stream.Position = 0;
             XacmlPolicy policy;
             using (XmlReader reader = XmlReader.Create(stream))

--- a/src/Altinn.ResourceRegistry.Core/IPolicyRepository.cs
+++ b/src/Altinn.ResourceRegistry.Core/IPolicyRepository.cs
@@ -1,6 +1,3 @@
-using System;
-using System.IO;
-using System.Threading.Tasks;
 using Azure;
 using Azure.Storage.Blobs.Models;
 
@@ -15,24 +12,27 @@ namespace Altinn.ResourceRegistry.Core
         /// Gets file stream for the policy file from blob storage, if it exists at the specified path.
         /// </summary>
         /// <param name="resourceId">The resource id</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
         /// <returns>File stream of the policy file</returns>
-        Task<Stream> GetPolicyAsync(string resourceId);
+        Task<Stream> GetPolicyAsync(string resourceId, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Gets file stream for the specified version of a policy file from blob storage, if it exists at the specified path.
         /// </summary>
         /// <param name="resourceId">The resource id</param>
         /// <param name="version">The blob storage version</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
         /// <returns>File stream of the policy file</returns>
-        Task<Stream> GetPolicyVersionAsync(string resourceId, string version);
+        Task<Stream> GetPolicyVersionAsync(string resourceId, string version, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Writes a file stream to blobstorage to the specified path.
         /// </summary>
         /// <param name="resourceId">The resourceId</param> 
         /// <param name="fileStream">File stream of the policy file to be written</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
         /// <returns>Azure response BlobContentInfo</returns>
-        Task<Response<BlobContentInfo>> WritePolicyAsync(string resourceId, Stream fileStream);
+        Task<Response<BlobContentInfo>> WritePolicyAsync(string resourceId, Stream fileStream, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Writes a file stream to blobstorage to the specified path, including the conditional check that the provided blob lease id is valid.
@@ -40,36 +40,41 @@ namespace Altinn.ResourceRegistry.Core
         /// <param name="resourceId">The resourceId</param> 
         /// <param name="fileStream">File stream of the policy file to be written</param>
         /// <param name="blobLeaseId">The blob lease id, required to be able to write after a lock</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
         /// <returns>Azure response BlobContentInfo</returns>
-        Task<Response<BlobContentInfo>> WritePolicyConditionallyAsync(string resourceId, Stream fileStream, string blobLeaseId);
+        Task<Response<BlobContentInfo>> WritePolicyConditionallyAsync(string resourceId, Stream fileStream, string blobLeaseId, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Deletes a specific version of a blob storage file if it exits on the specified path.
         /// </summary>
         /// <param name="resourceId">The resourceId</param> 
         /// <param name="version">The blob storage version</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
         /// <returns></returns>
-        Task<Response> DeletePolicyVersionAsync(string resourceId, string version);
+        Task<Response> DeletePolicyVersionAsync(string resourceId, string version, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Tries to acquire a blob lease on the base blob for the provided filepath.
         /// </summary>
         /// <param name="resourceId">The resourceId</param> 
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
         /// <returns>The LeaseId if a release was possible, otherwise null</returns>
-        Task<string> TryAcquireBlobLease(string resourceId);
+        Task<string> TryAcquireBlobLease(string resourceId, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Releases a blob lease on the base blob for the resource policy for the provided resource id using the provided leaseId.
         /// </summary>
         /// <param name="resourceId">The resourceId</param> 
         /// <param name="leaseId">The lease id from to release</param>
-        void ReleaseBlobLease(string resourceId, string leaseId);
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
+        Task ReleaseBlobLease(string resourceId, string leaseId, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Checks whether there exists a blob for the specific resource
         /// </summary>
         /// <param name="resourceId">The resourceId</param> 
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
         /// <returns>Bool whether the blob exists or not</returns>
-        Task<bool> PolicyExistsAsync(string resourceId);
+        Task<bool> PolicyExistsAsync(string resourceId, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Altinn.ResourceRegistry.Core/IResourceRegistryRepository.cs
+++ b/src/Altinn.ResourceRegistry.Core/IResourceRegistryRepository.cs
@@ -11,34 +11,39 @@ namespace Altinn.ResourceRegistry.Core
         /// Gets a single resource by its resource identifier if it exists in the resource registry
         /// </summary>
         /// <param name="id">The resource identifier to retrieve</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> for cancelling the async process.</param>
         /// <returns>ServiceResource</returns>
-        Task<ServiceResource> GetResource(string id);
+        Task<ServiceResource> GetResource(string id, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Deletes a resource from the resource registry
         /// </summary>
         /// <param name="id">The resource identifier to delete</param>
-        Task<ServiceResource> DeleteResource(string id);
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> for cancelling the async process.</param>
+        Task<ServiceResource> DeleteResource(string id, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Updates a service resource in the resource registry if it pass all validation checks
         /// </summary>
         /// <param name="resource">Service resource model for update in the resource registry</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> for cancelling the async process.</param>
         /// <returns>The result of the operation</returns>
-        Task<ServiceResource> UpdateResource(ServiceResource resource);
+        Task<ServiceResource> UpdateResource(ServiceResource resource, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Creates a service resource in the resource registry if it pass all validation checks
         /// </summary>
         /// <param name="resource">Service resource model to create in the resource registry</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> for cancelling the async process.</param>
         /// <returns>The result of the operation</returns>
-        Task<ServiceResource> CreateResource(ServiceResource resource);
+        Task<ServiceResource> CreateResource(ServiceResource resource, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Allows for searching for resources in the resource registry
         /// </summary>
         /// <param name="resourceSearch">The search model defining the search filter criterias</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> for cancelling the async process.</param>
         /// <returns>A list of service resources found to match the search criterias</returns>
-        Task<List<ServiceResource>> Search(ResourceSearch resourceSearch);
+        Task<List<ServiceResource>> Search(ResourceSearch resourceSearch, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Altinn.ResourceRegistry.Core/Services/IAltinn2Services.cs
+++ b/src/Altinn.ResourceRegistry.Core/Services/IAltinn2Services.cs
@@ -12,16 +12,16 @@ namespace Altinn.ResourceRegistry.Core.Services
         /// <summary>
         /// Return a list of Available services from Altinn 2
         /// </summary>
-        public Task<List<AvailableService>> AvailableServices(int languageId);
+        public Task<List<AvailableService>> AvailableServices(int languageId, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Create a service resources based on a Altinn 2 service
         /// </summary>
-        Task<ServiceResource> GetServiceResourceFromService(string serviceCode, int serviceEditionCode);
+        Task<ServiceResource> GetServiceResourceFromService(string serviceCode, int serviceEditionCode, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// GEts the xacml policy for a service
         /// </summary>
-        Task<XacmlPolicy> GetXacmlPolicy(string serviceCode, int serviceEditionCode, string identifier);
+        Task<XacmlPolicy> GetXacmlPolicy(string serviceCode, int serviceEditionCode, string identifier, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Altinn.ResourceRegistry.Core/Services/IOrgListClient.cs
+++ b/src/Altinn.ResourceRegistry.Core/Services/IOrgListClient.cs
@@ -10,7 +10,8 @@ namespace Altinn.ResourceRegistry.Core.Services
         /// <summary>
         /// Returns a list of orga
         /// </summary>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
         /// <returns></returns>
-        public Task<OrgList> GetOrgList();
+        public Task<OrgList> GetOrgList(CancellationToken cancellationToken = default);
     }
 }

--- a/src/Altinn.ResourceRegistry.Core/Services/Interfaces/IApplications.cs
+++ b/src/Altinn.ResourceRegistry.Core/Services/Interfaces/IApplications.cs
@@ -10,7 +10,8 @@ namespace Altinn.ResourceRegistry.Core.Services.Interfaces
         /// <summary>
         /// Get a full list of Altinn 3 applications
         /// </summary>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
         /// <returns></returns>
-        Task<ApplicationList> GetApplicationList();
+        Task<ApplicationList> GetApplicationList(CancellationToken cancellationToken = default);
     }
 }

--- a/src/Altinn.ResourceRegistry.Core/Services/Interfaces/IResourceRegistry.cs
+++ b/src/Altinn.ResourceRegistry.Core/Services/Interfaces/IResourceRegistry.cs
@@ -1,4 +1,5 @@
-﻿using Altinn.ResourceRegistry.Core.Models;
+﻿using System.Buffers;
+using Altinn.ResourceRegistry.Core.Models;
 
 namespace Altinn.ResourceRegistry.Core.Services.Interfaces
 {
@@ -62,7 +63,7 @@ namespace Altinn.ResourceRegistry.Core.Services.Interfaces
         /// <param name="fileStream">The file stream to the policy file</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
         /// <returns>Bool if storing the policy was successfull</returns>
-        Task<bool> StorePolicy(ServiceResource serviceResource, Stream fileStream, CancellationToken cancellationToken = default);
+        Task<bool> StorePolicy(ServiceResource serviceResource, ReadOnlySequence<byte> fileStream, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Returns the policy for a service resource

--- a/src/Altinn.ResourceRegistry.Core/Services/Interfaces/IResourceRegistry.cs
+++ b/src/Altinn.ResourceRegistry.Core/Services/Interfaces/IResourceRegistry.cs
@@ -11,62 +11,73 @@ namespace Altinn.ResourceRegistry.Core.Services.Interfaces
         /// Gets a single resource by its resource identifier if it exists in the resource registry
         /// </summary>
         /// <param name="id">The resource identifier to retrieve</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
         /// <returns>ServiceResource</returns>
-        Task<ServiceResource> GetResource(string id);
+        Task<ServiceResource> GetResource(string id, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Returns the full list of 
         /// </summary>
+        /// <param name="includeApps">Wheather or not to include apps</param>
+        /// <param name="includeAltinn2">Wheather or not to include altinn 2 resources</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
         /// <returns></returns>
-        Task<List<ServiceResource>> GetResourceList(bool includeApps, bool includeAltinn2);
+        Task<List<ServiceResource>> GetResourceList(bool includeApps, bool includeAltinn2, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Creates a service resource in the resource registry if it pass all validation checks
         /// </summary>
         /// <param name="serviceResource">Service resource model to create in the resource registry</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
         /// <returns>The result of the operation</returns>
-        Task CreateResource(ServiceResource serviceResource);
+        Task CreateResource(ServiceResource serviceResource, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Updates a service resource in the resource registry if it pass all validation checks
         /// </summary>
         /// <param name="serviceResource">Service resource model for update in the resource registry</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
         /// <returns>The result of the operation</returns>
-        Task UpdateResource(ServiceResource serviceResource);
+        Task UpdateResource(ServiceResource serviceResource, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Deletes a resource from the resource registry
         /// </summary>
         /// <param name="id">The resource identifier to delete</param>
-        Task Delete(string id);
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
+        Task Delete(string id, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Allows for searching for resources in the resource registry
         /// </summary>
         /// <param name="resourceSearch">The search model defining the search filter criterias</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
         /// <returns>A list of service resources found to match the search criterias</returns>
-        Task<List<ServiceResource>> Search(ResourceSearch resourceSearch);
+        Task<List<ServiceResource>> Search(ResourceSearch resourceSearch, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Allows for storing a policy xacml policy for the resource
         /// </summary>
         /// <param name="serviceResource">The resource</param>
         /// <param name="fileStream">The file stream to the policy file</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
         /// <returns>Bool if storing the policy was successfull</returns>
-        Task<bool> StorePolicy(ServiceResource serviceResource, Stream fileStream);
+        Task<bool> StorePolicy(ServiceResource serviceResource, Stream fileStream, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Returns the policy for a service resource
         /// </summary>
         /// <param name="resourceId">The resource id</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
         /// <returns></returns>
-        Task<Stream> GetPolicy(string resourceId);
+        Task<Stream> GetPolicy(string resourceId, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Updates Access management with changes in recource registry
         /// </summary>
         /// <param name="serviceResource">The resource to add to access management</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
         /// <returns></returns>
-        Task<bool> UpdateResourceInAccessManagement(ServiceResource serviceResource);
+        Task<bool> UpdateResourceInAccessManagement(ServiceResource serviceResource, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Altinn.ResourceRegistry.Core/Services/Interfaces/IResourceRegistry.cs
+++ b/src/Altinn.ResourceRegistry.Core/Services/Interfaces/IResourceRegistry.cs
@@ -60,10 +60,10 @@ namespace Altinn.ResourceRegistry.Core.Services.Interfaces
         /// Allows for storing a policy xacml policy for the resource
         /// </summary>
         /// <param name="serviceResource">The resource</param>
-        /// <param name="fileStream">The file stream to the policy file</param>
+        /// <param name="policyContent">The file stream to the policy file</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
         /// <returns>Bool if storing the policy was successfull</returns>
-        Task<bool> StorePolicy(ServiceResource serviceResource, ReadOnlySequence<byte> fileStream, CancellationToken cancellationToken = default);
+        Task<bool> StorePolicy(ServiceResource serviceResource, ReadOnlySequence<byte> policyContent, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Returns the policy for a service resource

--- a/src/Altinn.ResourceRegistry.Core/Services/ResourceRegistryService.cs
+++ b/src/Altinn.ResourceRegistry.Core/Services/ResourceRegistryService.cs
@@ -35,13 +35,19 @@ namespace Altinn.ResourceRegistry.Core.Services
         /// </summary>
         /// <param name="repository">Resource registry repository implementation for dependencies to its operations</param>
         /// <param name="policyRepository">Repository implementation for operations on policies</param>
-        /// <param name="logger">Logger</param>
         /// <param name="accessManagementClient">client to send data to AccessManagement</param>
         /// <param name="altinn2ServicesClient">Used to retrieve information from Altinn 2</param>
         /// <param name="applicationsClient">Used to retrieve information from Altinn Storage about Altinn 3 apps</param>
         /// <param name="orgList">Client to retrive orglist</param>
         /// <param name="memoryCache">Memorycache</param>
-        public ResourceRegistryService(IResourceRegistryRepository repository, IPolicyRepository policyRepository, ILogger<ResourceRegistryService> logger, IAccessManagementClient accessManagementClient, IAltinn2Services altinn2ServicesClient, IApplications applicationsClient, IOrgListClient orgList, IMemoryCache memoryCache)
+        public ResourceRegistryService(
+            IResourceRegistryRepository repository, 
+            IPolicyRepository policyRepository, 
+            IAccessManagementClient accessManagementClient, 
+            IAltinn2Services altinn2ServicesClient, 
+            IApplications applicationsClient, 
+            IOrgListClient orgList, 
+            IMemoryCache memoryCache)
         {
             _repository = repository;
             _policyRepository = policyRepository;
@@ -53,209 +59,241 @@ namespace Altinn.ResourceRegistry.Core.Services
         }
 
         /// <inheritdoc/>
-        public async Task CreateResource(ServiceResource serviceResource)
+        public async Task CreateResource(ServiceResource serviceResource, CancellationToken cancellationToken = default)
         {
-            bool result = await UpdateResourceInAccessManagement(serviceResource);
+            bool result = await UpdateResourceInAccessManagement(serviceResource, cancellationToken);
             if (!result)
             {
                 throw new AccessManagementUpdateException("Updating Access management failed");
             }
 
-            await _repository.CreateResource(serviceResource);
+            await _repository.CreateResource(serviceResource, cancellationToken);
         }
 
         /// <inheritdoc/>
-        public async Task UpdateResource(ServiceResource serviceResource)
+        public async Task UpdateResource(ServiceResource serviceResource, CancellationToken cancellationToken = default)
         {
-            bool result = await UpdateResourceInAccessManagement(serviceResource);
+            bool result = await UpdateResourceInAccessManagement(serviceResource, cancellationToken);
             if (!result)
             {
                 throw new AccessManagementUpdateException("Updating Access management failed");
             }
 
-            await _repository.UpdateResource(serviceResource);
+            await _repository.UpdateResource(serviceResource, cancellationToken);
         }
 
         /// <inheritdoc/>
-        public async Task Delete(string id)
+        public async Task Delete(string id, CancellationToken cancellationToken = default)
         {
-            await _repository.DeleteResource(id);
+            await _repository.DeleteResource(id, cancellationToken);
         }
 
         /// <inheritdoc/>
-        public async Task<ServiceResource> GetResource(string id)
+        public async Task<ServiceResource> GetResource(string id, CancellationToken cancellationToken = default)
         {
-            return await _repository.GetResource(id);
+            return await _repository.GetResource(id, cancellationToken);
         }
 
         /// <inheritdoc/>
-        public async Task<List<ServiceResource>> Search(ResourceSearch resourceSearch)
+        public async Task<List<ServiceResource>> Search(ResourceSearch resourceSearch, CancellationToken cancellationToken = default)
         {
-            return await _repository.Search(resourceSearch);
+            return await _repository.Search(resourceSearch, cancellationToken);
         }
 
         /// <inheritdoc/>
-        public async Task<bool> StorePolicy(ServiceResource serviceResource, Stream fileStream)
+        public async Task<bool> StorePolicy(ServiceResource serviceResource, Stream fileStream, CancellationToken cancellationToken = default)
         {
             PolicyHelper.IsValidResourcePolicy(serviceResource, fileStream);
-            Response<BlobContentInfo> response = await _policyRepository.WritePolicyAsync(serviceResource.Identifier, fileStream);
+            Response<BlobContentInfo> response = await _policyRepository.WritePolicyAsync(serviceResource.Identifier, fileStream, cancellationToken);
 
             return response?.GetRawResponse()?.Status == (int)HttpStatusCode.Created;
         }
 
         /// <inheritdoc/>
-        public async Task<Stream> GetPolicy(string resourceId)
+        public async Task<Stream> GetPolicy(string resourceId, CancellationToken cancellationToken = default)
         {
-              return await _policyRepository.GetPolicyAsync(resourceId);
+              return await _policyRepository.GetPolicyAsync(resourceId, cancellationToken);
         }
 
         /// <inheritdoc />
-        public async Task<bool> UpdateResourceInAccessManagement(ServiceResource serviceResource)
+        public async Task<bool> UpdateResourceInAccessManagement(ServiceResource serviceResource, CancellationToken cancellationToken = default)
         {
             AccessManagementResource convertedElement = new AccessManagementResource(serviceResource);
             List<AccessManagementResource> convertedElementList = convertedElement.ElementToList();
-            HttpResponseMessage response = await _accessManagementClient.AddResourceToAccessManagement(convertedElementList);
+            HttpResponseMessage response = await _accessManagementClient.AddResourceToAccessManagement(convertedElementList, cancellationToken);
 
             return response.StatusCode == HttpStatusCode.Created;
         }
 
         /// <inheritdoc />
-        public async Task<List<ServiceResource>> GetResourceList(bool includeApps, bool includeAltinn2)
+        public async Task<List<ServiceResource>> GetResourceList(bool includeApps, bool includeAltinn2, CancellationToken cancellationToken = default)
         {
-            List<ServiceResource> serviceResources = new List<ServiceResource>();
-
-            ResourceSearch resourceSearch = new ResourceSearch();
-            
-            List<ServiceResource> resources = await Search(resourceSearch);
-
-            foreach (ServiceResource resource in resources)
+            var tasks = new List<Task<List<ServiceResource>>>(3)
             {
-                resource.AuthorizationReference = new List<AuthorizationReferenceAttribute>
+                GetResourceListInner(cancellationToken),
+            };
+
+            if (includeApps || includeAltinn2)
+            {
+                var orgListTask = GetOrgList(cancellationToken);
+                
+                if (includeAltinn2)
                 {
-                    new AuthorizationReferenceAttribute() { Id = "urn:altinn:resource", Value = resource.Identifier }
-                };
-            }
-
-            serviceResources.AddRange(resources);
-            await AddAltinn2AvailableServices(serviceResources);
-            await AddAltinn3Applications(serviceResources);
-
-            return serviceResources;
-        }
-
-        private async Task AddAltinn3Applications(List<ServiceResource> serviceResources)
-        {
-            ApplicationList applicationList = await _applicationsClient.GetApplicationList();
-
-            foreach (Application application in applicationList.Applications)
-            {
-                serviceResources.Add(await MapApplicationToApplicationResource(application));
-            }
-        }
-
-        private async Task AddAltinn2AvailableServices(List<ServiceResource> serviceResources)
-        {
-            List<AvailableService> altinn2List1044 = await _altinn2ServicesClient.AvailableServices(1044);
-            List<AvailableService> altinn2List2068 = await _altinn2ServicesClient.AvailableServices(2068);
-            List<AvailableService> altinn2List1033 = await _altinn2ServicesClient.AvailableServices(1033);
-
-            foreach (AvailableService service in altinn2List1044)
-            {
-                string nntext = string.Empty;
-                string entext = string.Empty;
-
-                AvailableService service2068 = altinn2List2068.Find(r => r.ExternalServiceCode == service.ExternalServiceCode && r.ExternalServiceEditionCode == service.ExternalServiceEditionCode);
-                if (service2068 != null)
-                {
-                    nntext = service2068.ServiceEditionVersionName;
+                    tasks.Add(GetAltinn2AvailableServices(orgListTask, cancellationToken));
                 }
                 
-                AvailableService service1033 = altinn2List1033.Find(r => r.ExternalServiceCode == service.ExternalServiceCode && r.ExternalServiceEditionCode == service.ExternalServiceEditionCode);
-                if (service1033 != null)
+                if (includeApps)
                 {
-                    entext = service1033.ServiceEditionVersionName;
-                }
-
-                serviceResources.Add(await MapAltinn2ServiceToServiceResource(service, entext, nntext));
-            }
-        }
-
-        private async Task<ServiceResource> MapAltinn2ServiceToServiceResource(AvailableService availableService, string entext, string nntext)
-        {
-            OrgList orgList = await GetOrgList();
-            ServiceResource serviceResource = new ServiceResource();
-            serviceResource.ResourceType = Enums.ResourceType.Altinn2Service;
-            serviceResource.Title = new Dictionary<string, string>
-            {
-                { "nb", availableService.ServiceEditionVersionName },
-                { "en", entext },
-                { "nn", nntext }
-            };
-            serviceResource.ResourceReferences = new List<ResourceReference>();
-            serviceResource.Identifier = $"{ResourceConstants.SERVICE_ENGINE_RESOURCE_PREFIX}{availableService.ExternalServiceCode}_{availableService.ExternalServiceEditionCode.ToString()}";
-            serviceResource.ResourceReferences.Add(new ResourceReference() { ReferenceType = Enums.ReferenceType.ServiceCode, Reference = availableService.ExternalServiceCode, ReferenceSource = Enums.ReferenceSource.Altinn2 });
-            serviceResource.ResourceReferences.Add(new ResourceReference() { ReferenceType = Enums.ReferenceType.ServiceEditionCode, Reference = availableService.ExternalServiceEditionCode.ToString(), ReferenceSource = Enums.ReferenceSource.Altinn2 });
-            serviceResource.AuthorizationReference = new List<AuthorizationReferenceAttribute>
-            {
-                new AuthorizationReferenceAttribute() { Id = "urn:altinn:servicecode", Value = availableService.ExternalServiceCode },
-                new AuthorizationReferenceAttribute() { Id = "urn:altinn:serviceeditioncode", Value = availableService.ExternalServiceEditionCode.ToString() }
-            };
-            serviceResource.HasCompetentAuthority = new CompetentAuthority();
-            serviceResource.HasCompetentAuthority.Orgcode = availableService.ServiceOwnerCode.ToLower();
-            if (orgList.Orgs.TryGetValue(serviceResource.HasCompetentAuthority.Orgcode.ToLower(), out Org orgentity))
-            {
-                serviceResource.HasCompetentAuthority.Organization = orgentity.Orgnr;
-                serviceResource.HasCompetentAuthority.Name = orgentity.Name;
-            }
-
-            return serviceResource;
-        }
-
-        private async Task<ServiceResource> MapApplicationToApplicationResource(Application application)
-        {
-            OrgList orgList = await GetOrgList();
-            ServiceResource service = new ServiceResource();
-            service.Title = application.Title;
-            service.Identifier = $"{ResourceConstants.APPLICATION_RESOURCE_PREFIX}{application.Org}_{application.Id.Substring(application.Id.IndexOf("/") + 1)}";
-            service.ResourceType = Enums.ResourceType.AltinnApp;
-            service.ResourceReferences = new List<ResourceReference>
-            {
-                new ResourceReference() { ReferenceSource = Enums.ReferenceSource.Altinn3, ReferenceType = Enums.ReferenceType.ApplicationId, Reference = application.Id }
-            };
-            service.AuthorizationReference = new List<AuthorizationReferenceAttribute>
-            {
-                new AuthorizationReferenceAttribute() { Id = "urn:altinn:org", Value = application.Org },
-                new AuthorizationReferenceAttribute() { Id = "urn:altinn:app", Value = application.Id.Substring(application.Id.IndexOf("/") + 1) }
-            };
-            service.HasCompetentAuthority = new CompetentAuthority();
-            service.HasCompetentAuthority.Orgcode = application.Org.ToLower();
-            if (orgList.Orgs.TryGetValue(service.HasCompetentAuthority.Orgcode, out Org orgentity))
-            {
-                service.HasCompetentAuthority.Organization = orgentity.Orgnr;
-                service.HasCompetentAuthority.Name = orgentity.Name;
-            }
-
-            return service;
-        }
-
-        private async Task<OrgList> GetOrgList()
-        {
-            string cacheKey = "fullorglist";
-
-            if (!_memoryCache.TryGetValue(cacheKey, out OrgList orgList))
-            {
-                orgList = await _orgList.GetOrgList();
-                var cacheEntryOptions = new MemoryCacheEntryOptions()
-                 .SetPriority(CacheItemPriority.High)
-                 .SetAbsoluteExpiration(new TimeSpan(0, 3600, 0));
-
-                if (orgList != null)
-                {
-                    _memoryCache.Set(cacheKey, orgList, cacheEntryOptions);
+                    tasks.Add(GetAltinn3Applications(orgListTask, cancellationToken));
                 }
             }
 
-            return orgList;
+            var resourceLists = await Task.WhenAll(tasks);
+            var resourcesCount = resourceLists.Sum(list => list.Count);
+            var resources = new List<ServiceResource>(resourcesCount);
+            foreach (var resourceList in resourceLists)
+            { 
+                resources.AddRange(resourceList);
+            }
+
+            return resources;
+
+            async Task<List<ServiceResource>> GetResourceListInner(CancellationToken cancellationToken)
+            {
+                ResourceSearch resourceSearch = new ResourceSearch();
+            
+                List<ServiceResource> resources = await Search(resourceSearch, cancellationToken);
+
+                foreach (ServiceResource resource in resources)
+                {
+                    resource.AuthorizationReference = new List<AuthorizationReferenceAttribute>
+                    {
+                        new AuthorizationReferenceAttribute() { Id = "urn:altinn:resource", Value = resource.Identifier }
+                    };
+                }
+
+                return resources;
+            }
+
+            async Task<List<ServiceResource>> GetAltinn3Applications(Task<OrgList> orgListTask, CancellationToken cancellationToken = default)
+            {
+                ApplicationList applicationList = await _applicationsClient.GetApplicationList(cancellationToken);
+                var orgList = await orgListTask;
+
+                return applicationList.Applications.Select(application => MapApplicationToApplicationResource(application, orgList)).ToList();
+            }
+
+            async Task<List<ServiceResource>> GetAltinn2AvailableServices(Task<OrgList> orgListTask, CancellationToken cancellationToken = default)
+            {
+                var altin2Services = await Task.WhenAll(
+                    _altinn2ServicesClient.AvailableServices(1044, cancellationToken),
+                    _altinn2ServicesClient.AvailableServices(2068, cancellationToken),
+                    _altinn2ServicesClient.AvailableServices(1033, cancellationToken));
+
+                List<AvailableService> altinn2List1044 = altin2Services[0];
+                List<AvailableService> altinn2List2068 = altin2Services[1];
+                List<AvailableService> altinn2List1033 = altin2Services[2];
+                var orgList = await orgListTask;
+
+                var serviceResources = new List<ServiceResource>(altinn2List1044.Count);
+                foreach (AvailableService service in altinn2List1044)
+                {
+                    string nntext = string.Empty;
+                    string entext = string.Empty;
+
+                    AvailableService service2068 = altinn2List2068.Find(r => r.ExternalServiceCode == service.ExternalServiceCode && r.ExternalServiceEditionCode == service.ExternalServiceEditionCode);
+                    if (service2068 != null)
+                    {
+                        nntext = service2068.ServiceEditionVersionName;
+                    }
+                    
+                    AvailableService service1033 = altinn2List1033.Find(r => r.ExternalServiceCode == service.ExternalServiceCode && r.ExternalServiceEditionCode == service.ExternalServiceEditionCode);
+                    if (service1033 != null)
+                    {
+                        entext = service1033.ServiceEditionVersionName;
+                    }
+
+                    serviceResources.Add(MapAltinn2ServiceToServiceResource(service, orgList, entext, nntext));
+                }
+
+                return serviceResources;
+            }
+
+            ServiceResource MapAltinn2ServiceToServiceResource(AvailableService availableService, OrgList orgList, string entext, string nntext)
+            {
+                ServiceResource serviceResource = new ServiceResource();
+                serviceResource.ResourceType = Enums.ResourceType.Altinn2Service;
+                serviceResource.Title = new Dictionary<string, string>
+                {
+                    { "nb", availableService.ServiceEditionVersionName },
+                    { "en", entext },
+                    { "nn", nntext }
+                };
+                serviceResource.ResourceReferences = new List<ResourceReference>();
+                serviceResource.Identifier = $"{ResourceConstants.SERVICE_ENGINE_RESOURCE_PREFIX}{availableService.ExternalServiceCode}_{availableService.ExternalServiceEditionCode.ToString()}";
+                serviceResource.ResourceReferences.Add(new ResourceReference() { ReferenceType = Enums.ReferenceType.ServiceCode, Reference = availableService.ExternalServiceCode, ReferenceSource = Enums.ReferenceSource.Altinn2 });
+                serviceResource.ResourceReferences.Add(new ResourceReference() { ReferenceType = Enums.ReferenceType.ServiceEditionCode, Reference = availableService.ExternalServiceEditionCode.ToString(), ReferenceSource = Enums.ReferenceSource.Altinn2 });
+                serviceResource.AuthorizationReference = new List<AuthorizationReferenceAttribute>
+                {
+                    new AuthorizationReferenceAttribute() { Id = "urn:altinn:servicecode", Value = availableService.ExternalServiceCode },
+                    new AuthorizationReferenceAttribute() { Id = "urn:altinn:serviceeditioncode", Value = availableService.ExternalServiceEditionCode.ToString() }
+                };
+                serviceResource.HasCompetentAuthority = new CompetentAuthority();
+                serviceResource.HasCompetentAuthority.Orgcode = availableService.ServiceOwnerCode.ToLower();
+                if (orgList.Orgs.TryGetValue(serviceResource.HasCompetentAuthority.Orgcode.ToLower(), out Org orgentity))
+                {
+                    serviceResource.HasCompetentAuthority.Organization = orgentity.Orgnr;
+                    serviceResource.HasCompetentAuthority.Name = orgentity.Name;
+                }
+
+                return serviceResource;
+            }
+
+            ServiceResource MapApplicationToApplicationResource(Application application, OrgList orgList)
+            {
+                ServiceResource service = new ServiceResource();
+                service.Title = application.Title;
+                service.Identifier = $"{ResourceConstants.APPLICATION_RESOURCE_PREFIX}{application.Org}_{application.Id.Substring(application.Id.IndexOf("/") + 1)}";
+                service.ResourceType = Enums.ResourceType.AltinnApp;
+                service.ResourceReferences = new List<ResourceReference>
+                {
+                    new ResourceReference() { ReferenceSource = Enums.ReferenceSource.Altinn3, ReferenceType = Enums.ReferenceType.ApplicationId, Reference = application.Id }
+                };
+                service.AuthorizationReference = new List<AuthorizationReferenceAttribute>
+                {
+                    new AuthorizationReferenceAttribute() { Id = "urn:altinn:org", Value = application.Org },
+                    new AuthorizationReferenceAttribute() { Id = "urn:altinn:app", Value = application.Id.Substring(application.Id.IndexOf("/") + 1) }
+                };
+                service.HasCompetentAuthority = new CompetentAuthority();
+                service.HasCompetentAuthority.Orgcode = application.Org.ToLower();
+                if (orgList.Orgs.TryGetValue(service.HasCompetentAuthority.Orgcode, out Org orgentity))
+                {
+                    service.HasCompetentAuthority.Organization = orgentity.Orgnr;
+                    service.HasCompetentAuthority.Name = orgentity.Name;
+                }
+
+                return service;
+            }
+
+            async Task<OrgList> GetOrgList(CancellationToken cancellationToken = default)
+            {
+                string cacheKey = "fullorglist";
+
+                if (!_memoryCache.TryGetValue(cacheKey, out OrgList orgList))
+                {
+                    orgList = await _orgList.GetOrgList(cancellationToken);
+                    var cacheEntryOptions = new MemoryCacheEntryOptions()
+                        .SetPriority(CacheItemPriority.High)
+                        .SetAbsoluteExpiration(new TimeSpan(0, 3600, 0));
+
+                    if (orgList != null)
+                    {
+                        _memoryCache.Set(cacheKey, orgList, cacheEntryOptions);
+                    }
+                }
+
+                return orgList;
+            }
         }
     }
 }

--- a/src/Altinn.ResourceRegistry.Core/Services/ResourceRegistryService.cs
+++ b/src/Altinn.ResourceRegistry.Core/Services/ResourceRegistryService.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System.Buffers;
+using System.Diagnostics;
 using System.Net;
 using Altinn.Platform.Storage.Interface.Models;
 using Altinn.ResourceRegistry.Core.Clients.Interfaces;
@@ -13,6 +14,7 @@ using Azure;
 using Azure.Storage.Blobs.Models;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
+using Nerdbank.Streams;
 
 namespace Altinn.ResourceRegistry.Core.Services
 {
@@ -101,10 +103,10 @@ namespace Altinn.ResourceRegistry.Core.Services
         }
 
         /// <inheritdoc/>
-        public async Task<bool> StorePolicy(ServiceResource serviceResource, Stream fileStream, CancellationToken cancellationToken = default)
+        public async Task<bool> StorePolicy(ServiceResource serviceResource, ReadOnlySequence<byte> policyContent, CancellationToken cancellationToken = default)
         {
-            PolicyHelper.IsValidResourcePolicy(serviceResource, fileStream);
-            Response<BlobContentInfo> response = await _policyRepository.WritePolicyAsync(serviceResource.Identifier, fileStream, cancellationToken);
+            PolicyHelper.IsValidResourcePolicy(serviceResource, policyContent);
+            Response<BlobContentInfo> response = await _policyRepository.WritePolicyAsync(serviceResource.Identifier, policyContent.AsStream(), cancellationToken);
 
             return response?.GetRawResponse()?.Status == (int)HttpStatusCode.Created;
         }

--- a/src/Altinn.ResourceRegistry.Integration/Clients/Altinn2ServicesClient.cs
+++ b/src/Altinn.ResourceRegistry.Integration/Clients/Altinn2ServicesClient.cs
@@ -27,14 +27,14 @@ namespace Altinn.ResourceRegistry.Integration.Clients
         }
 
         /// <inheritdoc/>
-        public async Task<List<AvailableService>?> AvailableServices(int languageId)
+        public async Task<List<AvailableService>?> AvailableServices(int languageId, CancellationToken cancellationToken = default)
         {
             List<AvailableService>? availableServices = null;
             string availabbleServicePath = _settings.BridgeApiEndpoint + $"metadata/api/availableServices?languageID={languageId}&appTypesToInclude=0&includeExpired=false";
 
             try
             {
-                HttpResponseMessage response = await _client.GetAsync(availabbleServicePath);
+                HttpResponseMessage response = await _client.GetAsync(availabbleServicePath, cancellationToken);
                 
                 string availableServiceString = await response.Content.ReadAsStringAsync();
                 if (!string.IsNullOrEmpty(availableServiceString))
@@ -51,15 +51,15 @@ namespace Altinn.ResourceRegistry.Integration.Clients
         }
 
         /// <inheritdoc/>
-        public async Task<ServiceResource?> GetServiceResourceFromService(string serviceCode, int serviceEditionCode)
+        public async Task<ServiceResource?> GetServiceResourceFromService(string serviceCode, int serviceEditionCode, CancellationToken cancellationToken = default)
         {
             string bridgeBaseUrl = _settings.BridgeApiEndpoint;
             string url = $"{bridgeBaseUrl}metadata/api/resourceregisterresource?serviceCode={serviceCode}&serviceEditionCode={serviceEditionCode}";
 
-            HttpResponseMessage response = await _client.GetAsync(url);
+            HttpResponseMessage response = await _client.GetAsync(url, cancellationToken);
             response.EnsureSuccessStatusCode();
 
-            string contentString = await response.Content.ReadAsStringAsync();
+            string contentString = await response.Content.ReadAsStringAsync(cancellationToken);
             if (string.IsNullOrEmpty(contentString))
             {
                 return null;
@@ -70,15 +70,15 @@ namespace Altinn.ResourceRegistry.Integration.Clients
         }
 
         /// <inheritdoc/>
-        public async Task<XacmlPolicy?> GetXacmlPolicy(string serviceCode, int serviceEditionCode, string identifier)
+        public async Task<XacmlPolicy?> GetXacmlPolicy(string serviceCode, int serviceEditionCode, string identifier, CancellationToken cancellationToken = default)
         {
             string bridgeBaseUrl = _settings.BridgeApiEndpoint;
             string url = $"{bridgeBaseUrl}authorization/api/resourcepolicyfile?serviceCode={serviceCode}&serviceEditionCode={serviceEditionCode}&identifier={identifier}";
 
-            HttpResponseMessage response = await _client.GetAsync(url);
+            HttpResponseMessage response = await _client.GetAsync(url, cancellationToken);
             response.EnsureSuccessStatusCode();
 
-            string contentString = await response.Content.ReadAsStringAsync();
+            string contentString = await response.Content.ReadAsStringAsync(cancellationToken);
             if (string.IsNullOrEmpty(contentString))
             {
                 return null;

--- a/src/Altinn.ResourceRegistry.Integration/Clients/Altinn2ServicesClient.cs
+++ b/src/Altinn.ResourceRegistry.Integration/Clients/Altinn2ServicesClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Xml;
+﻿using System.Text.Json;
+using System.Xml;
 using Altinn.Authorization.ABAC.Utils;
 using Altinn.Authorization.ABAC.Xacml;
 using Altinn.ResourceRegistry.Core.Configuration;
@@ -14,6 +15,10 @@ namespace Altinn.ResourceRegistry.Integration.Clients
     /// </summary>
     public class Altinn2ServicesClient : IAltinn2Services
     {
+        private static readonly JsonSerializerOptions SerializerOptions = new()
+        {
+        };
+
         private readonly HttpClient _client;
         private readonly PlatformSettings _settings;
 
@@ -36,10 +41,10 @@ namespace Altinn.ResourceRegistry.Integration.Clients
             {
                 HttpResponseMessage response = await _client.GetAsync(availabbleServicePath, cancellationToken);
                 
-                string availableServiceString = await response.Content.ReadAsStringAsync();
+                string availableServiceString = await response.Content.ReadAsStringAsync(cancellationToken);
                 if (!string.IsNullOrEmpty(availableServiceString))
                 {
-                    availableServices = System.Text.Json.JsonSerializer.Deserialize<List<AvailableService>>(availableServiceString, new System.Text.Json.JsonSerializerOptions());
+                    availableServices = JsonSerializer.Deserialize<List<AvailableService>>(availableServiceString, SerializerOptions);
                 }
 
                 return availableServices;
@@ -65,7 +70,7 @@ namespace Altinn.ResourceRegistry.Integration.Clients
                 return null;
             }
 
-            ServiceResource? serviceResource = System.Text.Json.JsonSerializer.Deserialize<ServiceResource>(contentString);
+            ServiceResource? serviceResource = JsonSerializer.Deserialize<ServiceResource>(contentString, SerializerOptions);
             return serviceResource;
         }
 

--- a/src/Altinn.ResourceRegistry.Integration/Clients/OrgListClient.cs
+++ b/src/Altinn.ResourceRegistry.Integration/Clients/OrgListClient.cs
@@ -1,7 +1,8 @@
-﻿using Altinn.ResourceRegistry.Core.Configuration;
+﻿using System.Net.Http.Json;
+using System.Text.Json;
+using Altinn.ResourceRegistry.Core.Configuration;
 using Altinn.ResourceRegistry.Core.Models;
 using Altinn.ResourceRegistry.Core.Services;
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
 
 namespace Altinn.ResourceRegistry.Integration.Clients
@@ -11,6 +12,11 @@ namespace Altinn.ResourceRegistry.Integration.Clients
     /// </summary>
     public class OrgListClient : IOrgListClient
     {
+        private static readonly JsonSerializerOptions SerializerOptions = new()
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        };
+
         private readonly HttpClient _client;
         private readonly ResourceRegistrySettings _settings;
 
@@ -26,22 +32,17 @@ namespace Altinn.ResourceRegistry.Integration.Clients
         /// <summary>
         /// Returns configured org list
         /// </summary>
-        public async Task<OrgList> GetOrgList()
+        public async Task<OrgList> GetOrgList(CancellationToken cancellationToken = default)
         {
-            OrgList orgList;
-
             try
             {
-                HttpResponseMessage response = await _client.GetAsync(_settings.OrgListEndpoint);
+                HttpResponseMessage response = await _client.GetAsync(_settings.OrgListEndpoint, cancellationToken);
                 if (response.IsSuccessStatusCode)
                 {
                     response = await _client.GetAsync(_settings.OrgListAlternativeEndpoint);
                 }
 
-                string orgListString = await response.Content.ReadAsStringAsync();
-                orgList = System.Text.Json.JsonSerializer.Deserialize<OrgList>(orgListString, new System.Text.Json.JsonSerializerOptions() { PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase });
-
-                return orgList;
+                return await response.Content.ReadFromJsonAsync<OrgList>(SerializerOptions, cancellationToken);
             }
             catch (Exception ex)
             {

--- a/src/Altinn.ResourceRegistry.Integration/Clients/OrgListClient.cs
+++ b/src/Altinn.ResourceRegistry.Integration/Clients/OrgListClient.cs
@@ -34,12 +34,14 @@ namespace Altinn.ResourceRegistry.Integration.Clients
         /// </summary>
         public async Task<OrgList> GetOrgList(CancellationToken cancellationToken = default)
         {
+            HttpResponseMessage? response = null;
             try
             {
-                HttpResponseMessage response = await _client.GetAsync(_settings.OrgListEndpoint, cancellationToken);
-                if (response.IsSuccessStatusCode)
+                response = await _client.GetAsync(_settings.OrgListEndpoint, cancellationToken);
+                if (!response.IsSuccessStatusCode)
                 {
-                    response = await _client.GetAsync(_settings.OrgListAlternativeEndpoint);
+                    response.Dispose();
+                    response = await _client.GetAsync(_settings.OrgListAlternativeEndpoint, cancellationToken);
                 }
 
                 return await response.Content.ReadFromJsonAsync<OrgList>(SerializerOptions, cancellationToken);
@@ -47,6 +49,10 @@ namespace Altinn.ResourceRegistry.Integration.Clients
             catch (Exception ex)
             {
                 throw new Exception($"Something went wrong when retrieving Action options", ex);
+            }
+            finally 
+            { 
+                response?.Dispose(); 
             }
         }
     }

--- a/src/Altinn.ResourceRegistry.Persistence/Altinn.ResourceRegistry.Persistence.csproj
+++ b/src/Altinn.ResourceRegistry.Persistence/Altinn.ResourceRegistry.Persistence.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.1" />
     <PackageReference Include="Npgsql" Version="7.0.6" />
+    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Altinn.ResourceRegistry.Persistence/Configuration/AzureStorageConfiguration.cs
+++ b/src/Altinn.ResourceRegistry.Persistence/Configuration/AzureStorageConfiguration.cs
@@ -1,33 +1,32 @@
-namespace Altinn.AccessGroups.Persistance
+namespace Altinn.ResourceRegistry.Persistence.Configuration;
+
+/// <summary>
+/// Settings for Azure storage
+/// </summary>
+public class AzureStorageConfiguration
 {
     /// <summary>
-    /// Settings for Azure storage
+    /// The storage account name for the resource registry
     /// </summary>
-    public class AzureStorageConfiguration
-    {
-        /// <summary>
-        /// The storage account name for the resource registry
-        /// </summary>
-        public string ResourceRegistryAccountName { get; set; }
+    public string ResourceRegistryAccountName { get; set; }
 
-        /// <summary>
-        /// The storage account key for the resource registry
-        /// </summary>
-        public string ResourceRegistryAccountKey { get; set; }
+    /// <summary>
+    /// The storage account key for the resource registry
+    /// </summary>
+    public string ResourceRegistryAccountKey { get; set; }
 
-        /// <summary>
-        /// The name of the storage container in the resource registry storage account
-        /// </summary>
-        public string ResourceRegistryContainer { get; set; }
+    /// <summary>
+    /// The name of the storage container in the resource registry storage account
+    /// </summary>
+    public string ResourceRegistryContainer { get; set; }
 
-        /// <summary>
-        /// The url for the blob end point for the resource registry
-        /// </summary>
-        public string ResourceRegistryBlobEndpoint { get; set; }
+    /// <summary>
+    /// The url for the blob end point for the resource registry
+    /// </summary>
+    public string ResourceRegistryBlobEndpoint { get; set; }
 
-        /// <summary>
-        /// The blob lease timeout value in seconds
-        /// </summary>
-        public int BlobLeaseTimeout { get; set; }
-    }
+    /// <summary>
+    /// The blob lease timeout value in seconds
+    /// </summary>
+    public int BlobLeaseTimeout { get; set; }
 }

--- a/src/Altinn.ResourceRegistry.Persistence/Configuration/PostgreSQLSettings.cs
+++ b/src/Altinn.ResourceRegistry.Persistence/Configuration/PostgreSQLSettings.cs
@@ -1,18 +1,17 @@
-﻿namespace Altinn.AccessGroups.Persistance
+﻿namespace Altinn.ResourceRegistry.Persistence.Configuration;
+
+/// <summary>
+/// Settings for Postgres database
+/// </summary>
+public class PostgreSQLSettings
 {
     /// <summary>
-    /// Settings for Postgres database
+    /// Connection string for the postgres db
     /// </summary>
-    public class PostgreSQLSettings
-    {
-        /// <summary>
-        /// Connection string for the postgres db
-        /// </summary>
-        public string ConnectionString { get; set; }
+    public string ConnectionString { get; set; }
 
-        /// <summary>
-        /// Password for app user for the postgres db
-        /// </summary>
-        public string AuthorizationDbPwd { get; set; }
-    }
+    /// <summary>
+    /// Password for app user for the postgres db
+    /// </summary>
+    public string AuthorizationDbPwd { get; set; }
 }

--- a/src/Altinn.ResourceRegistry.Persistence/Extensions/NpgsqlExtensions.cs
+++ b/src/Altinn.ResourceRegistry.Persistence/Extensions/NpgsqlExtensions.cs
@@ -1,0 +1,68 @@
+﻿using System.Runtime.CompilerServices;
+using Npgsql;
+using NpgsqlTypes;
+
+namespace Altinn.ResourceRegistry.Persistence.Extensions;
+
+/// <summary>
+/// Helper extensions for Npgsql.
+/// </summary>
+internal static class NpgsqlExtensions
+{
+    /// <summary>
+    /// Create a <see cref="NpgsqlCommand"/> with the command text set.
+    /// </summary>
+    /// <param name="conn">The <see cref="NpgsqlConnection"/>.</param>
+    /// <param name="sql">The command text as a string.</param>
+    /// <returns>A <see cref="NpgsqlCommand"/>.</returns>
+    public static NpgsqlCommand CreateCommand(this NpgsqlConnection conn, string sql)
+    {
+        var cmd = conn.CreateCommand();
+        cmd.CommandText = sql;
+        return cmd;
+    }
+
+    /// <summary>
+    /// Executes a command against the database, returning a <see cref="IAsyncEnumerable{T}"/>
+    /// that can be easily mapped over.
+    /// </summary>
+    /// <param name="cmd">The <see cref="NpgsqlCommand"/>.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+    /// <returns></returns>
+    public static async IAsyncEnumerable<NpgsqlDataReader> ExecuteEnumerableAsync(
+        this NpgsqlCommand cmd,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        await using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
+
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            yield return reader;
+        }
+    }
+
+    /// <summary>
+    /// Adds a <see cref="NpgsqlParameter"/> to the <see cref="NpgsqlParameterCollection"/> given the parameter name and the data type
+    /// and value.
+    /// </summary>
+    /// <param name="parameters">The <see cref="NpgsqlParameterCollection"/> to add the parameter to.</param>
+    /// <param name="parameterName">The name of the parameter.</param>
+    /// <param name="parameterType">One of the <see cref="NpgsqlDbType"/> values.</param>
+    /// <param name="value">The parameter value. If this is <see langword="null"/>, <see cref="DBNull.Value"/> is used instead.</param>
+    /// <returns>The index of the new <see cref="NpgsqlParameter"/> object.</returns>
+    public static NpgsqlParameter AddWithNullableValue(
+        this NpgsqlParameterCollection parameters,
+        string parameterName,
+        NpgsqlDbType parameterType,
+        object? value)
+    {
+        var param = parameters.Add(parameterName, parameterType);
+        param.Value = value;
+        if (value is null)
+        {
+            param.Value = DBNull.Value;
+        }
+
+        return param;
+    }
+}

--- a/src/Altinn.ResourceRegistry.Persistence/Extensions/ResourceRegistryDependencyInjectionExtensions.cs
+++ b/src/Altinn.ResourceRegistry.Persistence/Extensions/ResourceRegistryDependencyInjectionExtensions.cs
@@ -1,0 +1,47 @@
+﻿using Altinn.ResourceRegistry.Core;
+using Altinn.ResourceRegistry.Core.Enums;
+using Altinn.ResourceRegistry.Persistence;
+using Altinn.ResourceRegistry.Persistence.Configuration;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Npgsql;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// Extension methods for adding resource registry services to the dependency injection container.
+/// </summary>
+public static class ResourceRegistryDependencyInjectionExtensions 
+{
+    /// <summary>
+    /// Registers a <see cref="IResourceRegistryRepository"/> with the dependency injection container.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/>.</param>
+    /// <returns><paramref name="services"/> for further chaining.</returns>
+    public static IServiceCollection AddResourceRegistryRepository(
+        this IServiceCollection services)
+    {
+        services.AddOptions<PostgreSQLSettings>()
+            .Validate(s => !string.IsNullOrEmpty(s.ConnectionString), "connection string cannot be null or empty")
+            .Validate(s => !string.IsNullOrEmpty(s.AuthorizationDbPwd), "connection string password be null or empty");
+
+        services.TryAddSingleton((IServiceProvider sp) =>
+        {
+            var settings = sp.GetRequiredService<IOptions<PostgreSQLSettings>>().Value;
+            var connectionString = string.Format(
+                settings.ConnectionString,
+                settings.AuthorizationDbPwd);
+
+            var builder = new NpgsqlDataSourceBuilder(connectionString);
+            builder.UseLoggerFactory(sp.GetRequiredService<ILoggerFactory>());
+            builder.MapEnum<ResourceType>("resourceregistry.resourcetype");
+            return builder.Build();
+        });
+
+        services.TryAddTransient((IServiceProvider sp) => sp.GetRequiredService<NpgsqlDataSource>().CreateConnection());
+        services.TryAddTransient<IResourceRegistryRepository, ResourceRegistryRepository>();
+
+        return services;
+    }
+}

--- a/src/Altinn.ResourceRegistry.Persistence/Extensions/ResourceRegistryDependencyInjectionExtensions.cs
+++ b/src/Altinn.ResourceRegistry.Persistence/Extensions/ResourceRegistryDependencyInjectionExtensions.cs
@@ -15,6 +15,20 @@ namespace Microsoft.Extensions.DependencyInjection;
 public static class ResourceRegistryDependencyInjectionExtensions 
 {
     /// <summary>
+    /// Registers resource registry persistence services with the dependency injection container.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/>.</param>
+    /// <returns><paramref name="services"/> for further chaining.</returns>
+    public static IServiceCollection AddResourceRegistryPersistence(
+        this IServiceCollection services)
+    {
+        services.AddResourceRegistryRepository();
+        services.AddResourceRegistryPolicyRepository();
+
+        return services;
+    }
+
+    /// <summary>
     /// Registers a <see cref="IResourceRegistryRepository"/> with the dependency injection container.
     /// </summary>
     /// <param name="services">The <see cref="IServiceCollection"/>.</param>
@@ -41,6 +55,25 @@ public static class ResourceRegistryDependencyInjectionExtensions
 
         services.TryAddTransient((IServiceProvider sp) => sp.GetRequiredService<NpgsqlDataSource>().CreateConnection());
         services.TryAddTransient<IResourceRegistryRepository, ResourceRegistryRepository>();
+
+        return services;
+    }
+
+    /// <summary>
+    /// Registers a <see cref="IPolicyRepository"/> with the dependency injection container.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/>.</param>
+    /// <returns><paramref name="services"/> for further chaining.</returns>
+    public static IServiceCollection AddResourceRegistryPolicyRepository(
+        this IServiceCollection services)
+    {
+        services.AddOptions<AzureStorageConfiguration>()
+            .Validate(s => !string.IsNullOrEmpty(s.ResourceRegistryAccountKey), "account key cannot be null or empty")
+            .Validate(s => !string.IsNullOrEmpty(s.ResourceRegistryAccountName), "account name cannot be null or empty")
+            .Validate(s => !string.IsNullOrEmpty(s.ResourceRegistryContainer), "container cannot be null or empty")
+            .Validate(s => !string.IsNullOrEmpty(s.ResourceRegistryBlobEndpoint), "blob endpoint cannot be null or empty");
+
+        services.TryAddSingleton<IPolicyRepository, PolicyRepository>();
 
         return services;
     }

--- a/src/Altinn.ResourceRegistry.Persistence/PolicyRepository.cs
+++ b/src/Altinn.ResourceRegistry.Persistence/PolicyRepository.cs
@@ -46,7 +46,7 @@ internal class PolicyRepository : IPolicyRepository
         string filePath = $"{resourceId.AsFilePath()}/resourcepolicy.xml";
         BlobClient blobClient = CreateBlobClient(filePath);
 
-        return await GetBlobStreamInternal(blobClient);
+        return await GetBlobStreamInternal(blobClient, cancellationToken);
     }
 
     /// <inheritdoc/>
@@ -55,7 +55,7 @@ internal class PolicyRepository : IPolicyRepository
         string filePath = $"{resourceId.AsFilePath()}/resourcepolicy.xml";
         BlobClient blobClient = CreateBlobClient(filePath).WithVersion(version);
 
-        return await GetBlobStreamInternal(blobClient);
+        return await GetBlobStreamInternal(blobClient, cancellationToken);
     }
 
     /// <inheritdoc/>

--- a/src/Altinn.ResourceRegistry.Persistence/PolicyRepository.cs
+++ b/src/Altinn.ResourceRegistry.Persistence/PolicyRepository.cs
@@ -1,8 +1,8 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
-using Altinn.AccessGroups.Persistance;
 using Altinn.ResourceRegistry.Core;
 using Altinn.ResourceRegistry.Core.Extensions;
+using Altinn.ResourceRegistry.Persistence.Configuration;
 using Azure;
 using Azure.Storage;
 using Azure.Storage.Blobs;
@@ -11,212 +11,215 @@ using Azure.Storage.Blobs.Specialized;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
-namespace Altinn.ResourceRegistry.Persistence
+namespace Altinn.ResourceRegistry.Persistence;
+
+/// <summary>
+/// Repository for handling policy files
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class PolicyRepository : IPolicyRepository
 {
+    private readonly ILogger<PolicyRepository> _logger;
+    private readonly AzureStorageConfiguration _storageConfig;
+    private readonly BlobContainerClient _resourceRegisterContainerClient;
+
     /// <summary>
-    /// Repository for handling policy files
+    /// Initializes a new instance of the <see cref="PolicyRepository"/> class
     /// </summary>
-    [ExcludeFromCodeCoverage]
-    public class PolicyRepository : IPolicyRepository
+    /// <param name="storageConfig">The storage configuration for Azure Blob Storage.</param>
+    /// <param name="logger">logger</param>
+    public PolicyRepository(
+        IOptions<AzureStorageConfiguration> storageConfig,
+        ILogger<PolicyRepository> logger)
     {
-        private readonly ILogger<PolicyRepository> _logger;
-        private readonly AzureStorageConfiguration _storageConfig;
-        private readonly BlobContainerClient _resourceRegisterContainerClient;
+        _logger = logger;
+        _storageConfig = storageConfig.Value;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PolicyRepository"/> class
-        /// </summary>
-        /// <param name="storageConfig">The storage configuration for Azure Blob Storage.</param>
-        /// <param name="logger">logger</param>
-        public PolicyRepository(
-            IOptions<AzureStorageConfiguration> storageConfig,
-            ILogger<PolicyRepository> logger)
+        StorageSharedKeyCredential resourceRegisterCredentials = new StorageSharedKeyCredential(_storageConfig.ResourceRegistryAccountName, _storageConfig.ResourceRegistryAccountKey);
+        BlobServiceClient resourceRegisterServiceClient = new BlobServiceClient(new Uri(_storageConfig.ResourceRegistryBlobEndpoint), resourceRegisterCredentials);
+        _resourceRegisterContainerClient = resourceRegisterServiceClient.GetBlobContainerClient(_storageConfig.ResourceRegistryContainer);
+    }
+
+    /// <inheritdoc/>
+    public async Task<Stream> GetPolicyAsync(string resourceId, CancellationToken cancellationToken = default)
+    {
+        string filePath = $"{resourceId.AsFilePath()}/resourcepolicy.xml";
+        BlobClient blobClient = CreateBlobClient(filePath);
+
+        return await GetBlobStreamInternal(blobClient);
+    }
+
+    /// <inheritdoc/>
+    public async Task<Stream> GetPolicyVersionAsync(string resourceId, string version, CancellationToken cancellationToken = default)
+    {
+        string filePath = $"{resourceId.AsFilePath()}/resourcepolicy.xml";
+        BlobClient blobClient = CreateBlobClient(filePath).WithVersion(version);
+
+        return await GetBlobStreamInternal(blobClient);
+    }
+
+    /// <inheritdoc/>
+    public async Task<Response<BlobContentInfo>> WritePolicyAsync(string resourceId, Stream fileStream, CancellationToken cancellationToken = default)
+    {
+        string filePath = $"{resourceId.AsFilePath()}/resourcepolicy.xml";
+        BlobClient blobClient = CreateBlobClient(filePath);
+
+        return await WriteBlobStreamInternal(blobClient, fileStream, cancellationToken: cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task<Response<BlobContentInfo>> WritePolicyConditionallyAsync(string resourceId, Stream fileStream, string blobLeaseId, CancellationToken cancellationToken = default)
+    {
+        string filePath = $"{resourceId.AsFilePath()}/resourcepolicy.xml";
+        BlobClient blobClient = CreateBlobClient(filePath);
+
+        BlobUploadOptions blobUploadOptions = new BlobUploadOptions()
         {
-            _logger = logger;
-            _storageConfig = storageConfig.Value;
+            Conditions = new BlobRequestConditions()
+            {
+                LeaseId = blobLeaseId
+            }
+        };
 
-            StorageSharedKeyCredential resourceRegisterCredentials = new StorageSharedKeyCredential(_storageConfig.ResourceRegistryAccountName, _storageConfig.ResourceRegistryAccountKey);
-            BlobServiceClient resourceRegisterServiceClient = new BlobServiceClient(new Uri(_storageConfig.ResourceRegistryBlobEndpoint), resourceRegisterCredentials);
-            _resourceRegisterContainerClient = resourceRegisterServiceClient.GetBlobContainerClient(_storageConfig.ResourceRegistryContainer);
+        return await WriteBlobStreamInternal(blobClient, fileStream, blobUploadOptions, cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task<string?> TryAcquireBlobLease(string resourceId, CancellationToken cancellationToken = default)
+    {
+        string filePath = $"{resourceId.AsFilePath()}/resourcepolicy.xml";
+        BlobClient blobClient = CreateBlobClient(filePath);
+        BlobLeaseClient blobLeaseClient = blobClient.GetBlobLeaseClient();
+
+        try
+        {
+            BlobLease blobLease = await blobLeaseClient.AcquireAsync(TimeSpan.FromSeconds(_storageConfig.BlobLeaseTimeout), cancellationToken: cancellationToken);
+            return blobLease.LeaseId;
+        }
+        catch (RequestFailedException ex)
+        {
+            _logger.LogError(ex, "Failed to acquire blob lease for policy file at {filepath}. RequestFailedException", filePath);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to acquire blob lease for policy file at {filepath}. Unexpected error", filePath);
         }
 
-        /// <inheritdoc/>
-        public async Task<Stream> GetPolicyAsync(string resourceId)
+        return null;
+    }
+
+    /// <inheritdoc/>
+    public async Task ReleaseBlobLease(string resourceId, string leaseId, CancellationToken cancellationToken = default)
+    {
+        string filePath = $"{resourceId.AsFilePath()}/resourcepolicy.xml";
+        BlobClient blobClient = CreateBlobClient(filePath);
+        BlobLeaseClient blobLeaseClient = blobClient.GetBlobLeaseClient(leaseId);
+        await blobLeaseClient.ReleaseAsync(cancellationToken: cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task<bool> PolicyExistsAsync(string resourceId, CancellationToken cancellationToken = default)
+    {
+        string filePath = $"{resourceId.AsFilePath()}/resourcepolicy.xml";
+        try
         {
-            string filePath = $"{resourceId.AsFilePath()}/resourcepolicy.xml";
             BlobClient blobClient = CreateBlobClient(filePath);
-
-            return await GetBlobStreamInternal(blobClient);
+            return await blobClient.ExistsAsync(cancellationToken);
+        }
+        catch (RequestFailedException ex)
+        {
+            _logger.LogError(ex, "Failed to check if blob exists for policy file at {filepath}. RequestFailedException", filePath);
         }
 
-        /// <inheritdoc/>
-        public async Task<Stream> GetPolicyVersionAsync(string resourceId, string version)
-        {
-            string filePath = $"{resourceId.AsFilePath()}/resourcepolicy.xml";
-            BlobClient blobClient = CreateBlobClient(filePath).WithVersion(version);
+        return false;
+    }
 
-            return await GetBlobStreamInternal(blobClient);
+    /// <inheritdoc/>
+    public async Task<Response> DeletePolicyVersionAsync(string resourceId, string version, CancellationToken cancellationToken = default)
+    {
+        string filePath = $"{resourceId.AsFilePath()}/resourcepolicy.xml";
+        try
+        {
+            BlobClient blockBlob = CreateBlobClient(filePath);
+
+            return await blockBlob.WithVersion(version).DeleteAsync(cancellationToken: cancellationToken);
         }
-
-        /// <inheritdoc/>
-        public async Task<Response<BlobContentInfo>> WritePolicyAsync(string resourceId, Stream fileStream)
+        catch (RequestFailedException ex)
         {
-            string filePath = $"{resourceId.AsFilePath()}/resourcepolicy.xml";
-            BlobClient blobClient = CreateBlobClient(filePath);
-
-            return await WriteBlobStreamInternal(blobClient, fileStream);
-        }
-
-        /// <inheritdoc/>
-        public async Task<Response<BlobContentInfo>> WritePolicyConditionallyAsync(string resourceId, Stream fileStream, string blobLeaseId)
-        {
-            string filePath = $"{resourceId.AsFilePath()}/resourcepolicy.xml";
-            BlobClient blobClient = CreateBlobClient(filePath);
-
-            BlobUploadOptions blobUploadOptions = new BlobUploadOptions()
+            if (ex.Status == (int)HttpStatusCode.Forbidden && ex.ErrorCode == "OperationNotAllowedOnRootBlob")
             {
-                Conditions = new BlobRequestConditions()
-                {
-                    LeaseId = blobLeaseId
-                }
-            };
-
-            return await WriteBlobStreamInternal(blobClient, fileStream, blobUploadOptions);
-        }
-
-        /// <inheritdoc/>
-        public async Task<string> TryAcquireBlobLease(string resourceId)
-        {
-            string filePath = $"{resourceId.AsFilePath()}/resourcepolicy.xml";
-            BlobClient blobClient = CreateBlobClient(filePath);
-            BlobLeaseClient blobLeaseClient = blobClient.GetBlobLeaseClient();
-
-            try
-            {
-                BlobLease blobLease = await blobLeaseClient.AcquireAsync(TimeSpan.FromSeconds(_storageConfig.BlobLeaseTimeout));
-                return blobLease.LeaseId;
-            }
-            catch (RequestFailedException ex)
-            {
-                _logger.LogError(ex, "Failed to acquire blob lease for policy file at {filepath}. RequestFailedException", filePath);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to acquire blob lease for policy file at {filepath}. Unexpected error", filePath);
-            }
-
-            return null;
-        }
-
-        /// <inheritdoc/>
-        public async void ReleaseBlobLease(string resourceId, string leaseId)
-        {
-            string filePath = $"{resourceId.AsFilePath()}/resourcepolicy.xml";
-            BlobClient blobClient = CreateBlobClient(filePath);
-            BlobLeaseClient blobLeaseClient = blobClient.GetBlobLeaseClient(leaseId);
-            await blobLeaseClient.ReleaseAsync();
-        }
-
-        /// <inheritdoc/>
-        public async Task<bool> PolicyExistsAsync(string resourceId)
-        {
-            string filePath = $"{resourceId.AsFilePath()}/resourcepolicy.xml";
-            try
-            {
-                BlobClient blobClient = CreateBlobClient(filePath);
-                return await blobClient.ExistsAsync();
-            }
-            catch (RequestFailedException ex)
-            {
-                _logger.LogError(ex, "Failed to check if blob exists for policy file at {filepath}. RequestFailedException", filePath);
-            }
-
-            return false;
-        }
-
-        /// <inheritdoc/>
-        public async Task<Response> DeletePolicyVersionAsync(string resourceId, string version)
-        {
-            string filePath = $"{resourceId.AsFilePath()}/resourcepolicy.xml";
-            try
-            {
-                BlobClient blockBlob = CreateBlobClient(filePath);
-
-                return await blockBlob.WithVersion(version).DeleteAsync();
-            }
-            catch (RequestFailedException ex)
-            {
-                if (ex.Status == (int)HttpStatusCode.Forbidden && ex.ErrorCode == "OperationNotAllowedOnRootBlob")
-                {
-                    _logger.LogError(ex, "Failed to delete version {version} of policy file at {filepath}. Not allowed to delete current version.", version, filePath);
-                    throw;
-                }
-
-                _logger.LogError(ex, "Failed to delete version {version} of policy file at {filepath}. RequestFailedException", version, filePath);
+                _logger.LogError(ex, "Failed to delete version {version} of policy file at {filepath}. Not allowed to delete current version.", version, filePath);
                 throw;
             }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to delete version {version} of policy file at {filepath}. Unexpected error", version, filePath);
-                throw;
-            }
+
+            _logger.LogError(ex, "Failed to delete version {version} of policy file at {filepath}. RequestFailedException", version, filePath);
+            throw;
         }
-
-        private BlobClient CreateBlobClient(string blobName)
+        catch (Exception ex)
         {
-            return _resourceRegisterContainerClient.GetBlobClient(blobName);
+            _logger.LogError(ex, "Failed to delete version {version} of policy file at {filepath}. Unexpected error", version, filePath);
+            throw;
         }
+    }
 
-        private async Task<Stream> GetBlobStreamInternal(BlobClient blobClient)
+    private BlobClient CreateBlobClient(string blobName)
+    {
+        return _resourceRegisterContainerClient.GetBlobClient(blobName);
+    }
+
+    private async Task<Stream> GetBlobStreamInternal(BlobClient blobClient, CancellationToken cancellationToken = default)
+    {
+        try
         {
-            try
+            Stream memoryStream = new MemoryStream();
+
+            if (await blobClient.ExistsAsync(cancellationToken))
             {
-                Stream memoryStream = new MemoryStream();
-
-                if (await blobClient.ExistsAsync())
-                {
-                    await blobClient.DownloadToAsync(memoryStream);
-                    memoryStream.Position = 0;
-
-                    return memoryStream;
-                }
+                await blobClient.DownloadToAsync(memoryStream, cancellationToken);
+                memoryStream.Position = 0;
 
                 return memoryStream;
             }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to read policy file at {blobClient.Name}.", blobClient.Name);
-                throw;
-            }
+
+            return memoryStream;
         }
-
-        private async Task<Response<BlobContentInfo>> WriteBlobStreamInternal(BlobClient blobClient, Stream fileStream, BlobUploadOptions blobUploadOptions = null)
+        catch (Exception ex)
         {
-            try
-            {
-                if (blobUploadOptions != null)
-                {
-                    return await blobClient.UploadAsync(fileStream, blobUploadOptions);
-                }
+            _logger.LogError(ex, "Failed to read policy file at {blobClient.Name}.", blobClient.Name);
+            throw;
+        }
+    }
 
-                return await blobClient.UploadAsync(fileStream, true);
+    private async Task<Response<BlobContentInfo>> WriteBlobStreamInternal(
+        BlobClient blobClient, 
+        Stream fileStream, 
+        BlobUploadOptions? blobUploadOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            if (blobUploadOptions != null)
+            {
+                return await blobClient.UploadAsync(fileStream, blobUploadOptions, cancellationToken);
             }
-            catch (RequestFailedException ex)
-            {
-                if (ex.Status == (int)HttpStatusCode.PreconditionFailed)
-                {
-                    _logger.LogError(ex, "Failed to save policy file {blobClient.Name}. Precondition failed", blobClient.Name);
-                    throw;
-                }
 
-                _logger.LogError(ex, "Failed to save policy file {blobClient.Name}. RequestFailedException", blobClient.Name);
+            return await blobClient.UploadAsync(fileStream, true, cancellationToken);
+        }
+        catch (RequestFailedException ex)
+        {
+            if (ex.Status == (int)HttpStatusCode.PreconditionFailed)
+            {
+                _logger.LogError(ex, "Failed to save policy file {blobClient.Name}. Precondition failed", blobClient.Name);
                 throw;
             }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to save policy file {blobClient.Name}. Unexpected exception", blobClient.Name);
-                throw;
-            }
+
+            _logger.LogError(ex, "Failed to save policy file {blobClient.Name}. RequestFailedException", blobClient.Name);
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to save policy file {blobClient.Name}. Unexpected exception", blobClient.Name);
+            throw;
         }
     }
 }

--- a/src/Altinn.ResourceRegistry.Persistence/PolicyRepository.cs
+++ b/src/Altinn.ResourceRegistry.Persistence/PolicyRepository.cs
@@ -17,7 +17,7 @@ namespace Altinn.ResourceRegistry.Persistence;
 /// Repository for handling policy files
 /// </summary>
 [ExcludeFromCodeCoverage]
-public class PolicyRepository : IPolicyRepository
+internal class PolicyRepository : IPolicyRepository
 {
     private readonly ILogger<PolicyRepository> _logger;
     private readonly AzureStorageConfiguration _storageConfig;

--- a/src/Altinn.ResourceRegistry.Persistence/ResourceRegistryRepository.cs
+++ b/src/Altinn.ResourceRegistry.Persistence/ResourceRegistryRepository.cs
@@ -53,10 +53,7 @@ internal class ResourceRegistryRepository : IResourceRegistryRepository
 
         try
         {
-            await using var conn = _conn.OpenConnection();
-            var trans = await conn.BeginTransactionAsync();
-
-            await using var pgcom = conn.CreateCommand(QUERY);
+            await using var pgcom = _conn.CreateCommand(QUERY);
             pgcom.Parameters.AddWithNullableValue("id", NpgsqlDbType.Text, resourceSearch.Id);
             pgcom.Parameters.AddWithNullableValue("title", NpgsqlDbType.Text, resourceSearch.Title);
             pgcom.Parameters.AddWithNullableValue("description", NpgsqlDbType.Text, resourceSearch.Description);

--- a/src/ResourceRegistry/Controllers/ResourceController.cs
+++ b/src/ResourceRegistry/Controllers/ResourceController.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ApplicationModels;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
+using Nerdbank.Streams;
 
 namespace Altinn.ResourceRegistry.Controllers
 {
@@ -288,7 +289,8 @@ namespace Altinn.ResourceRegistry.Controllers
 
             try
             {
-                bool successfullyStored = await _resourceRegistry.StorePolicy(resource, fileStream, cancellationToken);
+                using var policyFileContent = await fileStream.ReadToSequenceAsync(cancellationToken);
+                bool successfullyStored = await _resourceRegistry.StorePolicy(resource, policyFileContent.AsReadOnlySequence, cancellationToken);
                
                 if (successfullyStored)
                 {

--- a/src/ResourceRegistry/Program.cs
+++ b/src/ResourceRegistry/Program.cs
@@ -1,6 +1,5 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using Altinn.AccessGroups.Persistance;
 using Altinn.Common.AccessTokenClient.Services;
 using Altinn.Common.Authentication.Configuration;
 using Altinn.Common.PEP.Authorization;
@@ -17,6 +16,7 @@ using Altinn.ResourceRegistry.Filters;
 using Altinn.ResourceRegistry.Health;
 using Altinn.ResourceRegistry.Integration.Clients;
 using Altinn.ResourceRegistry.Persistence;
+using Altinn.ResourceRegistry.Persistence.Configuration;
 using AltinnCore.Authentication.JwtCookie;
 using Azure.Identity;
 using Azure.Security.KeyVault.Secrets;
@@ -78,7 +78,7 @@ void ConfigureServices(IServiceCollection services, IConfiguration config)
     services.AddHealthChecks().AddCheck<HealthCheck>("resourceregistry_health_check");
 
     services.AddSingleton<IResourceRegistry, ResourceRegistryService>();
-    services.AddSingleton<IResourceRegistryRepository, ResourceRegistryRepository>();
+    services.AddResourceRegistryRepository();
     services.AddSingleton<IPRP, PRPClient>();
     services.AddSingleton<IPolicyRepository, PolicyRepository>();
     services.AddSingleton<IAuthorizationHandler, ScopeAccessHandler>();

--- a/src/ResourceRegistry/Program.cs
+++ b/src/ResourceRegistry/Program.cs
@@ -78,9 +78,8 @@ void ConfigureServices(IServiceCollection services, IConfiguration config)
     services.AddHealthChecks().AddCheck<HealthCheck>("resourceregistry_health_check");
 
     services.AddSingleton<IResourceRegistry, ResourceRegistryService>();
-    services.AddResourceRegistryRepository();
+    services.AddResourceRegistryPersistence();
     services.AddSingleton<IPRP, PRPClient>();
-    services.AddSingleton<IPolicyRepository, PolicyRepository>();
     services.AddSingleton<IAuthorizationHandler, ScopeAccessHandler>();
     services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
     services.AddSingleton<IAccessTokenGenerator, AccessTokenGenerator>();

--- a/test/ResourceRegistryTest/Altinn.ResourceRegistry.Tests.csproj
+++ b/test/ResourceRegistryTest/Altinn.ResourceRegistry.Tests.csproj
@@ -58,6 +58,10 @@
     <Folder Include="Data\Altinn3Storage\" />
     <Folder Include="Data\Policies\" />
   </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\.editorconfig" Link=".editorconfig" />
+  </ItemGroup>
 	
   <ItemGroup>
     <None Update="selfSignedTestCertificate.pfx">

--- a/test/ResourceRegistryTest/Mocks/AccessManagementMock.cs
+++ b/test/ResourceRegistryTest/Mocks/AccessManagementMock.cs
@@ -2,6 +2,7 @@
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using Altinn.ResourceRegistry.Core.Clients.Interfaces;
 using Altinn.ResourceRegistry.Core.Models;
@@ -10,7 +11,7 @@ namespace Altinn.ResourceRegistry.Tests.Mocks
 {
     public class AccessManagementMock : IAccessManagementClient
     {
-        public Task<HttpResponseMessage> AddResourceToAccessManagement(List<AccessManagementResource> resources)
+        public Task<HttpResponseMessage> AddResourceToAccessManagement(List<AccessManagementResource> resources, CancellationToken cancellationToken)
         {
             HttpResponseMessage responseMessage = new HttpResponseMessage
             {

--- a/test/ResourceRegistryTest/Mocks/Altinn2ServicesClientMock.cs
+++ b/test/ResourceRegistryTest/Mocks/Altinn2ServicesClientMock.cs
@@ -27,7 +27,7 @@ namespace Altinn.ResourceRegistry.Tests.Mocks
 
             if (File.Exists(availableServiceFilePath))
             {
-                string content = await File.ReadAllTextAsync(availableServiceFilePath);
+                string content = await File.ReadAllTextAsync(availableServiceFilePath, cancellationToken);
                 if (!string.IsNullOrEmpty(content))
                 {
                     availableServices = System.Text.Json.JsonSerializer.Deserialize<List<AvailableService>>(content, new System.Text.Json.JsonSerializerOptions());

--- a/test/ResourceRegistryTest/Mocks/Altinn2ServicesClientMock.cs
+++ b/test/ResourceRegistryTest/Mocks/Altinn2ServicesClientMock.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
 
@@ -18,7 +19,7 @@ namespace Altinn.ResourceRegistry.Tests.Mocks
 {
     public class Altinn2ServicesClientMock : IAltinn2Services
     {
-        public async Task<List<AvailableService>> AvailableServices(int languageId)
+        public async Task<List<AvailableService>> AvailableServices(int languageId, CancellationToken cancellationToken)
         {
             string availableServiceFilePath = Path.Combine(GetAltinn2TestDatafolder(), $"availableServices{languageId}.json");
 
@@ -43,9 +44,9 @@ namespace Altinn.ResourceRegistry.Tests.Mocks
             throw new FileNotFoundException("Could not find " + availableServiceFilePath);
         }
 
-        public async Task<ServiceResource> GetServiceResourceFromService(string serviceCode, int serviceEditionCode)
+        public async Task<ServiceResource> GetServiceResourceFromService(string serviceCode, int serviceEditionCode, CancellationToken cancellationToken)
         {
-            List<AvailableService> services = await AvailableServices(1044);
+            List<AvailableService> services = await AvailableServices(1044, cancellationToken);
             AvailableService? service = services.FirstOrDefault(r=> r.ExternalServiceCode == serviceCode);
 
             if(service == null) 
@@ -59,7 +60,7 @@ namespace Altinn.ResourceRegistry.Tests.Mocks
             return res;
         }
 
-        public Task<XacmlPolicy> GetXacmlPolicy(string serviceCode, int serviceEditionCode, string identifier)
+        public Task<XacmlPolicy> GetXacmlPolicy(string serviceCode, int serviceEditionCode, string identifier, CancellationToken cancellationToken)
         {
             string resourceId = Path.Combine(GetPolicyContainerPath(), "altinn_access_management", "resourcepolicy.xml");
             if (File.Exists(resourceId))

--- a/test/ResourceRegistryTest/Mocks/ApplicationsClientMock.cs
+++ b/test/ResourceRegistryTest/Mocks/ApplicationsClientMock.cs
@@ -6,13 +6,14 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Altinn.ResourceRegistry.Tests.Mocks
 {
     public class ApplicationsClientMock : IApplications
     {
-        public async Task<ApplicationList> GetApplicationList()
+        public async Task<ApplicationList> GetApplicationList(CancellationToken cancellationToken)
         {
             string applicationsFilePath = Path.Combine(GetAltinn2TestDatafolder(), $"applications.json");
 

--- a/test/ResourceRegistryTest/Mocks/PolicyRepositoryMock.cs
+++ b/test/ResourceRegistryTest/Mocks/PolicyRepositoryMock.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Altinn.ResourceRegistry.Core;
 using Azure;
@@ -11,12 +12,12 @@ namespace Altinn.ResourceRegistry.Tests.Mocks
 {
     public class PolicyRepositoryMock : IPolicyRepository
     {
-        public Task<Response> DeletePolicyVersionAsync(string filepath, string version)
+        public Task<Response> DeletePolicyVersionAsync(string filepath, string version, CancellationToken cancellationToken)
         {
             throw new NotImplementedException();
         }
 
-        public async Task<Stream> GetPolicyAsync(string resourceId)
+        public async Task<Stream> GetPolicyAsync(string resourceId, CancellationToken cancellationToken)
         {
             resourceId = Path.Combine(GetPolicyContainerPath(), resourceId, "resourcepolicy.xml");
             if (File.Exists(resourceId))
@@ -27,27 +28,27 @@ namespace Altinn.ResourceRegistry.Tests.Mocks
             return null;
         }
 
-        public Task<Stream> GetPolicyVersionAsync(string filepath, string version)
+        public Task<Stream> GetPolicyVersionAsync(string filepath, string version, CancellationToken cancellationToken)
         {
             throw new NotImplementedException();
         }
 
-        public Task<bool> PolicyExistsAsync(string filepath)
+        public Task<bool> PolicyExistsAsync(string filepath, CancellationToken cancellationToken)
         {
             throw new NotImplementedException();
         }
 
-        public void ReleaseBlobLease(string filepath, string leaseId)
+        public async Task ReleaseBlobLease(string filepath, string leaseId, CancellationToken cancellationToken)
         {
             throw new NotImplementedException();
         }
 
-        public Task<string> TryAcquireBlobLease(string filepath)
+        public Task<string> TryAcquireBlobLease(string filepath, CancellationToken cancellationToken)
         {
             throw new NotImplementedException();
         }
 
-        public Task<Response<BlobContentInfo>> WritePolicyAsync(string filepath, Stream fileStream)
+        public Task<Response<BlobContentInfo>> WritePolicyAsync(string filepath, Stream fileStream, CancellationToken cancellationToken)
         {
             BlobContentInfo mockedBlobInfo = BlobsModelFactory.BlobContentInfo(new ETag("ETagSuccess"), DateTime.Now, new byte[1], DateTime.Now.ToUniversalTime().ToString(), "encryptionKeySha256", "encryptionScope", 1);
             Mock<Response<BlobContentInfo>> mockResponse = new Mock<Response<BlobContentInfo>>();
@@ -60,7 +61,7 @@ namespace Altinn.ResourceRegistry.Tests.Mocks
             return Task.FromResult(mockResponse.Object);
         }
 
-        public Task<Response<BlobContentInfo>> WritePolicyConditionallyAsync(string filepath, Stream fileStream, string blobLeaseId)
+        public Task<Response<BlobContentInfo>> WritePolicyConditionallyAsync(string filepath, Stream fileStream, string blobLeaseId, CancellationToken cancellationToken)
         {
             throw new NotImplementedException();
         }

--- a/test/ResourceRegistryTest/Mocks/RegisterResourceRepositoryMock.cs
+++ b/test/ResourceRegistryTest/Mocks/RegisterResourceRepositoryMock.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Altinn.ResourceRegistry.Core;
 using Altinn.ResourceRegistry.Core.Models;
@@ -9,22 +10,22 @@ namespace Altinn.ResourceRegistry.Tests.Mocks
 {
     public class RegisterResourceRepositoryMock : IResourceRegistryRepository
     {
-        public async Task<ServiceResource> CreateResource(ServiceResource resource)
+        public async Task<ServiceResource> CreateResource(ServiceResource resource, CancellationToken cancellationToken = default)
         {
             return await Task.FromResult<ServiceResource>(null);
         }
 
-        public async Task<ServiceResource> UpdateResource(ServiceResource resource)
+        public async Task<ServiceResource> UpdateResource(ServiceResource resource, CancellationToken cancellationToken = default)
         {
             return await Task.FromResult<ServiceResource>(resource);
         }
 
-        public async Task<ServiceResource> DeleteResource(string id)
+        public async Task<ServiceResource> DeleteResource(string id, CancellationToken cancellationToken = default)
         {
             return await GetResource(id);
         }
 
-        public async Task<ServiceResource> GetResource(string id)
+        public async Task<ServiceResource> GetResource(string id, CancellationToken cancellationToken = default)
         {
             string resourcePath = GetResourcePath(id);
             if (File.Exists(resourcePath))
@@ -44,7 +45,7 @@ namespace Altinn.ResourceRegistry.Tests.Mocks
             return null;
         }
 
-        public async Task<List<ServiceResource>> Search(ResourceSearch resourceSearch)
+        public async Task<List<ServiceResource>> Search(ResourceSearch resourceSearch, CancellationToken cancellationToken = default)
         {
             List<ServiceResource> resources = new List<ServiceResource>();
             string[] files =  Directory.GetFiles(GetResourcePath());


### PR DESCRIPTION
Fix some issues with async usage in the code and move database queries into C#.

Things fixed:
 - Async methods should accept a cancellation token.
 - Removed a bunch of unused usings.
 - Added some missing doc-comments.
 - Removed some unnused service dependencies.
 - Improve hos persistence services are added to the denepdency container.
 - Add labels to some boolean arguments to make review easier.