### PR TITLE
Validate that resourceType app has correct identifier and resourceReferences

### DIFF
--- a/src/Altinn.ResourceRegistry.Core/Helpers/ServiceResourceHelper.cs
+++ b/src/Altinn.ResourceRegistry.Core/Helpers/ServiceResourceHelper.cs
@@ -80,6 +80,18 @@ namespace Altinn.ResourceRegistry.Core.Helpers
                 isValid = false;
             }
 
+            if (IsInvalidAppResourceReferences(serviceResource))
+            {
+                AddValidationMessage(validationMessages, "ResourceReferences", "Invalid app Resource. App resources needs to have a reference with ReferenceType ApplicationId");
+                isValid = false;
+            }
+
+            if (IsInvalidAppIdentifier(serviceResource))
+            {
+                AddValidationMessage(validationMessages, "Identifier", "Invalid identifier for app resource. App resources needs to have an identifier starting with app_<org>");
+                isValid = false;
+            }
+
             if (!ResourceIdentifierRegex().IsMatch(serviceResource.Identifier))
             {
                 AddValidationMessage(validationMessages, "Identifier", "Invalid id. Only a-z and 0-9 is allowed together with _ and -.  Minimum 4 characters");
@@ -171,6 +183,32 @@ namespace Altinn.ResourceRegistry.Core.Helpers
                     || !serviceResource.ResourceReferences.Exists(rf => rf.ReferenceType.HasValue && rf.ReferenceType.Equals(ReferenceType.ApplicationId))))
                 {
                     // Uses app prefix without it beeing a app resource
+                    return true;
+                }
+
+                return false;
+            }
+
+            static bool IsInvalidAppResourceReferences(ServiceResource serviceResource)
+            {
+                if (serviceResource.ResourceType == ResourceType.AltinnApp
+                    && (serviceResource.ResourceReferences == null
+                    || !serviceResource.ResourceReferences.Any()
+                    || !serviceResource.ResourceReferences.Exists(rf => rf.ReferenceType.HasValue && rf.ReferenceType.Equals(ReferenceType.ApplicationId))))
+                {
+                    // Uses app ResourceType without having correct ResourceReferences for app resource
+                    return true;
+                }
+
+                return false;
+            }
+
+            static bool IsInvalidAppIdentifier(ServiceResource serviceResource)
+            {
+                if (serviceResource.ResourceType == ResourceType.AltinnApp
+                    && !serviceResource.Identifier.StartsWith($"{ResourceConstants.APPLICATION_RESOURCE_PREFIX}_{serviceResource.HasCompetentAuthority.Orgcode}", StringComparison.OrdinalIgnoreCase))
+                {
+                    // Uses app ResourceType without having correct identifier prefix for app resource
                     return true;
                 }
 


### PR DESCRIPTION
## Description
- It is now possible to POST a resource with `resourceType: AltinnApp` which does not fulfill the requirements for app resources. This can lead to a NullPointerException in access management when looping through a list of app resources

## Related Issue(s)
- https://github.com/Altinn/altinn-resource-registry/issues/711

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
