### PR TITLE
fix: app identifier validation incorrectly expects double underscore

### DIFF
--- a/src/Altinn.ResourceRegistry.Core/Helpers/ServiceResourceHelper.cs
+++ b/src/Altinn.ResourceRegistry.Core/Helpers/ServiceResourceHelper.cs
@@ -206,7 +206,7 @@ namespace Altinn.ResourceRegistry.Core.Helpers
             static bool IsInvalidAppIdentifier(ServiceResource serviceResource)
             {
                 if (serviceResource.ResourceType == ResourceType.AltinnApp
-                    && !serviceResource.Identifier.StartsWith($"{ResourceConstants.APPLICATION_RESOURCE_PREFIX}_{serviceResource.HasCompetentAuthority.Orgcode}", StringComparison.OrdinalIgnoreCase))
+                    && !serviceResource.Identifier.StartsWith($"{ResourceConstants.APPLICATION_RESOURCE_PREFIX}{serviceResource.HasCompetentAuthority.Orgcode}", StringComparison.OrdinalIgnoreCase))
                 {
                     // Uses app ResourceType without having correct identifier prefix for app resource
                     return true;

--- a/test/Altinn.ResourceRegistry.Tests/ResourceControllerTest.cs
+++ b/test/Altinn.ResourceRegistry.Tests/ResourceControllerTest.cs
@@ -307,6 +307,52 @@ namespace Altinn.ResourceRegistry.Tests
         }
 
         [Fact]
+        public async Task CreateAppResource_WithValidIdentifier()
+        {
+            var client = CreateClient();
+            string token = PrincipalUtil.GetOrgToken("skd", "974761076", "altinn:resourceregistry/resource.write");
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+            ServiceResource resource = new ServiceResource()
+            {
+                Identifier = "app_skd_flyttemelding",
+                HasCompetentAuthority = new CompetentAuthority()
+                {
+                    Organization = "974761076",
+                    Orgcode = "skd",
+                },
+                ResourceType = ResourceType.AltinnApp,
+                ResourceReferences = new ()
+                {
+                    new ()
+                    {
+                        ReferenceSource = ReferenceSource.Altinn2,
+                        ReferenceType = ReferenceType.ApplicationId,
+                        Reference = "altinn:skd/flyttemelding"
+                    }
+                },
+                Title = new Dictionary<string, string> { { "en", "English" }, { "nb", "Bokmal" }, { "nn", "Nynorsk" } },
+                Description = new Dictionary<string, string> { { "en", "English" }, { "nb", "Bokmal" }, { "nn", "Nynorsk" } },
+                RightDescription = new Dictionary<string, string> { { "en", "English" }, { "nb", "Bokmal" }, { "nn", "Nynorsk" } },
+                ContactPoints = new List<ContactPoint>() { new ContactPoint() { Category = "Support", ContactPage = "support.skd.no", Email = "support@skd.no", Telephone = "+4790012345" } },
+            };
+
+            string requestUri = "resourceregistry/api/v1/Resource/";
+
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, requestUri)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(resource), Encoding.UTF8, "application/json")
+            };
+
+            httpRequestMessage.Headers.Add("Accept", "application/json");
+            httpRequestMessage.Headers.Add("ContentType", "application/json");
+
+            HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+
+            Assert.True(response.IsSuccessStatusCode);
+        }
+
+        [Fact]
         public async Task CreateResource_WithAdminScope()
         {
             var client = CreateClient();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

App identifier validation currently expects `app__{org}` (note the double underscore).

This is inconsistent with other locations in the codebase, e.g. https://github.com/Altinn/altinn-resource-registry/blob/c371838b6ea3d0235755ba0e2a53a787b489f678/src/Altinn.ResourceRegistry.Core/Services/ResourceRegistryService.cs#L332

This PR changes the validation to validate single underscore prefix, and also adds a test verifying that a valid altinnApp resource identifier passes validation. (The test is just a copied version of the one created in #712 to check for failing validation, but edited to match a valid resource)

## Related Issue(s)
- #712 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
