### PR TITLE
Filter migrated apps from resource registry database results

### DIFF
--- a/src/Altinn.ResourceRegistry.Core/Services/ResourceRegistryService.cs
+++ b/src/Altinn.ResourceRegistry.Core/Services/ResourceRegistryService.cs
@@ -269,6 +269,13 @@ namespace Altinn.ResourceRegistry.Core.Services
 
                 List<ServiceResource> resources = await Search(resourceSearch, includeAllVersions, cancellationToken);
 
+                if (!includeMigratedApps)
+                {
+                    resources = resources
+                        .Where(resource => !IsMigratedApplicationResource(resource))
+                        .ToList();
+                }
+
                 foreach (ServiceResource resource in resources)
                 {
                     // For app resources, use org/app format like Storage apps do
@@ -305,6 +312,11 @@ namespace Altinn.ResourceRegistry.Core.Services
                 }
 
                 return resources;
+
+                static bool IsMigratedApplicationResource(ServiceResource resource)
+                {
+                    return resource.ResourceType == Enums.ResourceType.MigratedApp;
+                }
             }
 
             async Task<List<ServiceResource>> GetAltinn3Applications(bool includeMigratedApps, CancellationToken cancellationToken = default)


### PR DESCRIPTION
@
## Description

The `includeMigratedApps` filter was only applied to the Storage/metadata API path (`GetAltinn3Applications` → `_applicationsClient.GetApplicationList(includeMigratedApps, ...)`). Resources read from the **resource registry database** via the `Search` path (`GetResourceListInner`) were never filtered.

As a result, once an A1/A2 app was migrated into the resource registry database, it was still returned in the resource list even when `includeMigratedApps=false`.

## Change

When `includeMigratedApps` is `false`, exclude resources with `ResourceType.MigratedApp` from the registry DB results.

The check is strict on `ResourceType` only (no identifier substring heuristic), since migration into the database was only enabled after `ResourceType` handling was in place — there are no untyped legacy migrated rows.

## Verification

- `dotnet build` of `Altinn.ResourceRegistry.Core` succeeds (0 warnings, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@