### PR TITLE
Resolve app resources directly from Storage instead of cached list

### DIFF
--- a/src/Altinn.ResourceRegistry.Core/Services/Interfaces/IApplications.cs
+++ b/src/Altinn.ResourceRegistry.Core/Services/Interfaces/IApplications.cs
@@ -14,5 +14,16 @@ namespace Altinn.ResourceRegistry.Core.Services.Interfaces
         /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
         /// <returns></returns>
         Task<ApplicationList> GetApplicationList(bool includeMigratedApps, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Get a single Altinn 3 application directly from Storage by org and app name.
+        /// Unlike <see cref="GetApplicationList"/> this bypasses the cached application list, so a freshly
+        /// published app is resolvable immediately instead of returning null until the list cache expires.
+        /// </summary>
+        /// <param name="org">The organisation/service owner code</param>
+        /// <param name="app">The application name (without the org prefix)</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
+        /// <returns>The application, or <see langword="null"/> if it does not exist</returns>
+        Task<Application> GetApplication(string org, string app, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Altinn.ResourceRegistry.Core/Services/Interfaces/IResourceRegistry.cs
+++ b/src/Altinn.ResourceRegistry.Core/Services/Interfaces/IResourceRegistry.cs
@@ -19,6 +19,18 @@ namespace Altinn.ResourceRegistry.Core.Services.Interfaces
         Task<ServiceResource> GetResource(string id, int? versionId,  CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Gets a single Altinn app as a <see cref="ServiceResource"/> directly from application storage.
+        /// Used for apps that are not registered as resources in the resource registry. Bypasses the cached
+        /// application list so a freshly published app is resolvable immediately instead of returning
+        /// <see langword="null"/> until the list cache expires.
+        /// </summary>
+        /// <param name="org">The organisation/service owner code</param>
+        /// <param name="app">The application name (without the org prefix)</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
+        /// <returns>The app as a service resource, or <see langword="null"/> if it does not exist</returns>
+        Task<ServiceResource> GetAppResource(string org, string app, CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Gets the resource owner for a given resource, or <see langword="null"/> if it has no owner.
         /// </summary>
         /// <param name="id">The resource identifier to retrieve</param>

--- a/src/Altinn.ResourceRegistry.Core/Services/ResourceRegistryService.cs
+++ b/src/Altinn.ResourceRegistry.Core/Services/ResourceRegistryService.cs
@@ -92,6 +92,19 @@ namespace Altinn.ResourceRegistry.Core.Services
         }
 
         /// <inheritdoc/>
+        public async Task<ServiceResource> GetAppResource(string org, string app, CancellationToken cancellationToken = default)
+        {
+            Application application = await _applicationsClient.GetApplication(org, app, cancellationToken);
+            if (application == null)
+            {
+                return null;
+            }
+
+            ServiceOwnerLookup serviceOwners = await _serviceOwnerService.GetServiceOwners(cancellationToken);
+            return MapApplicationToApplicationResource(application, serviceOwners);
+        }
+
+        /// <inheritdoc/>
         public async Task<Result<CompetentAuthorityReference>> GetResourceOwner(string id, CancellationToken cancellationToken = default)
         {
             return await _repository.GetResourceOwner(id, cancellationToken);
@@ -315,46 +328,50 @@ namespace Altinn.ResourceRegistry.Core.Services
 
                 return applicationList.Applications.Select(application => MapApplicationToApplicationResource(application, serviceOwners)).ToList();
             }
+        }
 
-            ServiceResource MapApplicationToApplicationResource(Application application, ServiceOwnerLookup serviceOwners)
+        /// <summary>
+        /// Maps an Altinn Storage <see cref="Application"/> to a <see cref="ServiceResource"/>. Shared by the
+        /// full resource list and the direct single-app lookup so both produce identical app resources.
+        /// </summary>
+        private static ServiceResource MapApplicationToApplicationResource(Application application, ServiceOwnerLookup serviceOwners)
+        {
+            ServiceResource service = new ServiceResource();
+            service.Title = application.Title;
+            service.Identifier = $"{ResourceConstants.APPLICATION_RESOURCE_PREFIX}{application.Org}_{application.Id.Substring(application.Id.IndexOf("/") + 1)}";
+            if (service.Identifier.Contains("_a2-") || service.Identifier.Contains("_a1-"))
             {
-                ServiceResource service = new ServiceResource();
-                service.Title = application.Title;
-                service.Identifier = $"{ResourceConstants.APPLICATION_RESOURCE_PREFIX}{application.Org}_{application.Id.Substring(application.Id.IndexOf("/") + 1)}";
-                if (service.Identifier.Contains("_a2-") || service.Identifier.Contains("_a1-"))
-                {
-                    service.ResourceType = Enums.ResourceType.MigratedApp;
-                }
-                else
-                {
-                    service.ResourceType = Enums.ResourceType.AltinnApp;
-                }
-
-                service.ResourceReferences = new List<ResourceReference>
-                {
-                    new ResourceReference() { ReferenceSource = Enums.ReferenceSource.Altinn3, ReferenceType = Enums.ReferenceType.ApplicationId, Reference = application.Id }
-                };
-                service.AuthorizationReference = new List<AuthorizationReferenceAttribute>
-                {
-                    new AuthorizationReferenceAttribute() { Id = "urn:altinn:org", Value = application.Org },
-                    new AuthorizationReferenceAttribute() { Id = "urn:altinn:app", Value = application.Id.Substring(application.Id.IndexOf("/") + 1) }
-                };
-                service.HasCompetentAuthority = new CompetentAuthority();
-                service.HasCompetentAuthority.Orgcode = application.Org.ToLower();
-                if (serviceOwners.TryGet(service.HasCompetentAuthority.Orgcode, out var orgentity))
-                {
-                    service.HasCompetentAuthority.Organization = orgentity.OrganizationNumber.ToString();
-                    service.HasCompetentAuthority.Name = orgentity.Name;
-                }
-
-                if (application.Id.StartsWith("a1-"))
-                {
-                    service.Delegable = false;
-                    service.Visible = false;
-                }
-
-                return service;
+                service.ResourceType = Enums.ResourceType.MigratedApp;
             }
+            else
+            {
+                service.ResourceType = Enums.ResourceType.AltinnApp;
+            }
+
+            service.ResourceReferences = new List<ResourceReference>
+            {
+                new ResourceReference() { ReferenceSource = Enums.ReferenceSource.Altinn3, ReferenceType = Enums.ReferenceType.ApplicationId, Reference = application.Id }
+            };
+            service.AuthorizationReference = new List<AuthorizationReferenceAttribute>
+            {
+                new AuthorizationReferenceAttribute() { Id = "urn:altinn:org", Value = application.Org },
+                new AuthorizationReferenceAttribute() { Id = "urn:altinn:app", Value = application.Id.Substring(application.Id.IndexOf("/") + 1) }
+            };
+            service.HasCompetentAuthority = new CompetentAuthority();
+            service.HasCompetentAuthority.Orgcode = application.Org.ToLower();
+            if (serviceOwners.TryGet(service.HasCompetentAuthority.Orgcode, out var orgentity))
+            {
+                service.HasCompetentAuthority.Organization = orgentity.OrganizationNumber.ToString();
+                service.HasCompetentAuthority.Name = orgentity.Name;
+            }
+
+            if (application.Id.StartsWith("a1-"))
+            {
+                service.Delegable = false;
+                service.Visible = false;
+            }
+
+            return service;
         }
 
         /// <inheritdoc/>

--- a/src/Altinn.ResourceRegistry.Integration/Clients/ApplicationsClient.cs
+++ b/src/Altinn.ResourceRegistry.Integration/Clients/ApplicationsClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http.Json;
+﻿using System.Net;
+using System.Net.Http.Json;
 using System.Text.Json;
 using Altinn.Platform.Storage.Interface.Models;
 using Altinn.ResourceRegistry.Core.Configuration;
@@ -69,6 +70,33 @@ namespace Altinn.ResourceRegistry.Integration.Clients
             catch (Exception ex)
             {
                 throw new Exception($"Something went wrong when retrieving applications", ex);
+            }
+        }
+
+        /// <inheritdoc/>
+        public async Task<Application?> GetApplication(string org, string app, CancellationToken cancellationToken = default)
+        {
+            // Direct single-app lookup against Storage. Intentionally NOT served from the cached
+            // application list ("applications"), so a freshly published app is resolvable immediately
+            // instead of returning null until the 10 minute list cache expires.
+            string applicationPath = _settings.StorageApiEndpoint + $"applications/{org}/{app}";
+
+            try
+            {
+                HttpResponseMessage response = await _client.GetAsync(applicationPath, cancellationToken);
+
+                if (response.StatusCode == HttpStatusCode.NotFound)
+                {
+                    return null;
+                }
+
+                response.EnsureSuccessStatusCode();
+
+                return await response.Content.ReadFromJsonAsync<Application>(SerializerOptions, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"Something went wrong when retrieving application {org}/{app}", ex);
             }
         }
     }

--- a/src/Altinn.ResourceRegistry/Controllers/ResourceController.cs
+++ b/src/Altinn.ResourceRegistry/Controllers/ResourceController.cs
@@ -89,11 +89,17 @@ namespace Altinn.ResourceRegistry.Controllers
 
             if (resource == null && id.StartsWith(ResourceConstants.APPLICATION_RESOURCE_PREFIX))
             {
-                List<ServiceResource> resourceList = await _resourceRegistry.GetResourceList(includeApps: true, includeExpired: true, includeMigratedApps: true, includeAllVersions:false, cancellationToken);
-                ServiceResource appResource = resourceList.FirstOrDefault(r => r.Identifier == id);
-                if (appResource != null)
+                // App not registered as a resource: resolve it directly from application storage instead of
+                // the cached resource list, so a freshly published app is returned immediately rather than
+                // 404 until the list cache expires. Only 404 when the app is missing from Storage as well.
+                string[] parts = id.Split('_', 3);
+                if (parts.Length == 3)
                 {
-                    return Ok(appResource);
+                    ServiceResource appResource = await _resourceRegistry.GetAppResource(parts[1], parts[2], cancellationToken);
+                    if (appResource != null)
+                    {
+                        return Ok(appResource);
+                    }
                 }
             }
 
@@ -414,8 +420,13 @@ namespace Altinn.ResourceRegistry.Controllers
 
             if (resource == null && id.StartsWith(ResourceConstants.APPLICATION_RESOURCE_PREFIX))
             {
-                List<ServiceResource> resourceList = await _resourceRegistry.GetResourceList(includeApps: true, includeExpired: true, includeMigratedApps: true, includeAllVersions: false, cancellationToken);
-                resource = resourceList.FirstOrDefault(r => r.Identifier == id);
+                // Resolve the app directly from application storage rather than the cached resource list,
+                // so policy can be written for an app that was just published.
+                string[] parts = id.Split('_', 3);
+                if (parts.Length == 3)
+                {
+                    resource = await _resourceRegistry.GetAppResource(parts[1], parts[2], cancellationToken);
+                }
             }
 
             if (resource == null)

--- a/test/Altinn.ResourceRegistry.Tests/ApplicationsClientTest.cs
+++ b/test/Altinn.ResourceRegistry.Tests/ApplicationsClientTest.cs
@@ -89,6 +89,62 @@ namespace Altinn.ResourceRegistry.Tests
             Assert.Contains(result.Applications, r => r.Id == "skd/a2-4223-160201");
         }
 
+        [Fact]
+        public async Task GetApplication_ExistingApp_ReturnsApplication_AndCallsSingleAppEndpoint()
+        {
+            // Arrange
+            _platformSettings.Value.StorageApiEndpoint = "http://localhost:5117/storage/api/v1/";
+            HttpRequestMessage? requestMessage = null;
+            var cache = new MemoryCache(new MemoryCacheOptions());
+
+            Mock<HttpMessageHandler> mockHttpMessageHandler = new Mock<HttpMessageHandler>();
+            mockHttpMessageHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Callback<HttpRequestMessage, CancellationToken>((rm, ct) => requestMessage = rm)
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = JsonContent.Create(new Application { Id = "skd/cluster-test", Org = "skd" })
+                });
+            HttpClient applicationsClient = new HttpClient(mockHttpMessageHandler.Object);
+            ApplicationsClient target = new ApplicationsClient(applicationsClient, _platformSettings, cache);
+
+            // Act
+            Application? result = await target.GetApplication("skd", "cluster-test", cancellationToken: default);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("skd/cluster-test", result.Id);
+            Assert.NotNull(requestMessage);
+            Assert.Equal("http://localhost:5117/storage/api/v1/applications/skd/cluster-test", requestMessage.RequestUri!.ToString());
+        }
+
+        [Fact]
+        public async Task GetApplication_NotFound_ReturnsNull()
+        {
+            // Arrange
+            _platformSettings.Value.StorageApiEndpoint = "http://localhost:5117/storage/api/v1/";
+            var cache = new MemoryCache(new MemoryCacheOptions());
+
+            Mock<HttpMessageHandler> mockHttpMessageHandler = new Mock<HttpMessageHandler>();
+            mockHttpMessageHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.NotFound
+                });
+            HttpClient applicationsClient = new HttpClient(mockHttpMessageHandler.Object);
+            ApplicationsClient target = new ApplicationsClient(applicationsClient, _platformSettings, cache);
+
+            // Act
+            Application? result = await target.GetApplication("nav", "flyttemelding", cancellationToken: default);
+
+            // Assert
+            Assert.Null(result);
+        }
+
         private async Task<ApplicationList> GetApplicationsData()
         {
             ApplicationList? applicationList = new ApplicationList();

--- a/test/Altinn.ResourceRegistry.Tests/Mocks/ApplicationsClientMock.cs
+++ b/test/Altinn.ResourceRegistry.Tests/Mocks/ApplicationsClientMock.cs
@@ -49,6 +49,13 @@ namespace Altinn.ResourceRegistry.Tests.Mocks
             throw new FileNotFoundException("Could not find testdatafolder");
         }
 
+        public async Task<Application?> GetApplication(string org, string app, CancellationToken cancellationToken = default)
+        {
+            ApplicationList applicationList = await GetApplicationList(true, cancellationToken);
+            string appId = $"{org}/{app}";
+            return applicationList.Applications.FirstOrDefault(a => a.Id.Equals(appId, StringComparison.OrdinalIgnoreCase));
+        }
+
         private static string? GetAltinn2TestDatafolder()
         {
             string? unitTestFolder = Path.GetDirectoryName(new Uri(typeof(PolicyRepositoryMock).Assembly.Location).LocalPath);

--- a/test/Altinn.ResourceRegistry.Tests/ResourceControllerTest.cs
+++ b/test/Altinn.ResourceRegistry.Tests/ResourceControllerTest.cs
@@ -119,6 +119,27 @@ namespace Altinn.ResourceRegistry.Tests
         }
 
         [Fact]
+        public async Task GetResource_app_not_in_registry_resolved_directly_from_storage_OK()
+        {
+            // app_skd_cluster-test is not registered as a resource (no file under Data/Resources), so the
+            // direct DB lookup misses. It must be resolved directly from application storage rather than the
+            // cached resource list, proving a freshly published app is returned immediately.
+            var client = CreateClient();
+            string requestUri = "resourceregistry/api/v1/Resource/app_skd_cluster-test";
+
+            HttpResponseMessage response = await client.GetAsync(requestUri);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            string responseContent = await response.Content.ReadAsStringAsync();
+            ServiceResource? resource = JsonSerializer.Deserialize<ServiceResource>(responseContent, new System.Text.Json.JsonSerializerOptions() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+
+            Assert.NotNull(resource);
+            Assert.Equal("app_skd_cluster-test", resource.Identifier);
+            Assert.Equal(ResourceType.AltinnApp, resource.ResourceType);
+        }
+
+        [Fact]
         public async Task Test_Nav_Get()
         {
             var client = CreateClient();


### PR DESCRIPTION
## Problem

`GET /resourceregistry/api/v1/resource/{id}` resolved `app_`-prefixed resources that are **not** registered in the resource registry by scanning the full resource list. The app part of that list is served from a **10-minute in-memory cache** (`ApplicationsClient`, key `"applications"`). A freshly published app was therefore invisible — returning **404** — until the cache expired, even though it already existed in Storage and could appear on the change feed / a publish event.

Closes #821.

## Change

Add a direct single-app lookup that bypasses the list cache:

- **`IApplications.GetApplication(org, app)`** → hits Storage `applications/{org}/{app}` (already exists in altinn-storage, `[AllowAnonymous]`, returns `Application`/200 or 404). 404 → `null`.
- **`IResourceRegistry.GetAppResource(org, app)`** → maps the app to a `ServiceResource`, reusing the extracted `MapApplicationToApplicationResource` so the list and the single-lookup produce identical app resources.
- **`ResourceController.Get`** and **`WritePolicy`** split the id into `org`/`app` (same pattern the policy endpoints already use) and call the direct lookup. 404 / "Unknown resource" only when the app is missing from Storage too.

Registry always wins: the direct DB lookup runs first, and Storage is only consulted on a miss.

## Tests

- Unit tests for `GetApplication`: found → calls `applications/{org}/{app}`; 404 → `null` (Docker-free, **passing locally**).
- Integration test resolving an app present only in Storage (`app_skd_cluster-test`) — runs under Testcontainers in CI.
- Existing `resourcelist` tests (exact identifiers + count) cover the shared mapping refactor.

## Notes / follow-up

- The single-app lookup is intentionally **uncached** — that is the point of the fix. If repeated lookups of non-existent apps put load on Storage, a fine-grained per-`org/app` cache with a short TTL + short negative cache can be added later (noted in #821).
- Same cached-list fallback existed in `WritePolicy` and is updated the same way for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
