### PR TITLE
feat(#830): orgcode and organizationid support in existing search filter implementation

### DIFF
--- a/src/Altinn.ResourceRegistry.Core/Helpers/ServiceResourceHelper.cs
+++ b/src/Altinn.ResourceRegistry.Core/Helpers/ServiceResourceHelper.cs
@@ -27,8 +27,13 @@ namespace Altinn.ResourceRegistry.Core.Helpers
 
             foreach (ServiceResource serviceResource in resourceList)
             {
-                if (MatchingIdentifier(serviceResource, resourceSearch) && MatchingDescription(serviceResource, resourceSearch) && MatchingResourceType(serviceResource, resourceSearch) && MatchingKeywords(serviceResource, resourceSearch)
-                    && MatchingReference(serviceResource, resourceSearch))
+                if (MatchingIdentifier(serviceResource, resourceSearch) &&
+                    MatchingResourceType(serviceResource, resourceSearch) &&
+                    MatchingOrgCode(serviceResource, resourceSearch) &&
+                    MatchingOrganizationId(serviceResource, resourceSearch) &&
+                    MatchingDescription(serviceResource, resourceSearch) &&
+                    MatchingKeywords(serviceResource, resourceSearch) &&
+                    MatchingReference(serviceResource, resourceSearch))
                 {
                     searchResults.Add(serviceResource);
                 }
@@ -285,6 +290,16 @@ namespace Altinn.ResourceRegistry.Core.Helpers
         private static bool MatchingIdentifier(ServiceResource resource, ResourceSearch resourceSearch)
         {
             return resourceSearch.Id == null || resource.Identifier.Contains(resourceSearch.Id, StringComparison.InvariantCultureIgnoreCase);
+        }
+
+        private static bool MatchingOrgCode(ServiceResource serviceResource, ResourceSearch resourceSearch)
+        {
+            return resourceSearch.OrgCode == null || (serviceResource.HasCompetentAuthority != null && serviceResource.HasCompetentAuthority.Orgcode?.Equals(resourceSearch.OrgCode, StringComparison.InvariantCultureIgnoreCase) == true);
+        }
+
+        private static bool MatchingOrganizationId(ServiceResource serviceResource, ResourceSearch resourceSearch)
+        {
+            return resourceSearch.OrganizationId == null || (serviceResource.HasCompetentAuthority != null && serviceResource.HasCompetentAuthority.Organization?.Equals(resourceSearch.OrganizationId , StringComparison.InvariantCultureIgnoreCase) == true);
         }
 
         private static bool MatchingDescription(ServiceResource resource, ResourceSearch resourceSearch)

--- a/src/Altinn.ResourceRegistry.Core/Models/ResourceSearch.cs
+++ b/src/Altinn.ResourceRegistry.Core/Models/ResourceSearch.cs
@@ -37,5 +37,15 @@ namespace Altinn.ResourceRegistry.Core.Models
         /// To search for a specific reference
         /// </summary>
         public string? Reference { get; set; }
+
+        /// <summary>
+        /// To search for a specific organization code
+        /// </summary>
+        public string? OrgCode { get; set; }
+
+        /// <summary>
+        /// To search for a specific organization number
+        /// </summary>
+        public string? OrganizationId { get; set; }
     }
 }

--- a/test/Altinn.ResourceRegistry.Tests/ResourceControllerWithDbTests.cs
+++ b/test/Altinn.ResourceRegistry.Tests/ResourceControllerWithDbTests.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.Platform.Storage.Interface.Models;
+using Altinn.Platform.Storage.Interface.Models;
 using Altinn.ResourceRegistry.Controllers;
 using Altinn.ResourceRegistry.Core;
 using Altinn.ResourceRegistry.Core.Constants;
@@ -23,6 +23,8 @@ public class ResourceControllerWithDbTests(DbFixture dbFixture, WebApplicationFi
         : WebApplicationTests(dbFixture, webApplicationFixture)
 {
     private const string ORG_NR = "974761076";
+
+    private static readonly JsonSerializerOptions _jsonOptions = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
 
     protected IResourceRegistryRepository Repository => Services.GetRequiredService<IResourceRegistryRepository>();
     protected AdvanceableTimeProvider TimeProvider => Services.GetRequiredService<AdvanceableTimeProvider>();
@@ -482,7 +484,7 @@ public class ResourceControllerWithDbTests(DbFixture dbFixture, WebApplicationFi
         HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
 
         string responseContent = await response.Content.ReadAsStringAsync();
-        List<ServiceResource>? resource = JsonSerializer.Deserialize<List<ServiceResource>>(responseContent, new System.Text.Json.JsonSerializerOptions() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }) as List<ServiceResource>;
+        List<ServiceResource>? resource = JsonSerializer.Deserialize<List<ServiceResource>>(responseContent, _jsonOptions) as List<ServiceResource>;
 
         Assert.NotNull(resource);
         Assert.Single(resource);
@@ -503,7 +505,7 @@ public class ResourceControllerWithDbTests(DbFixture dbFixture, WebApplicationFi
         HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
 
         string responseContent = await response.Content.ReadAsStringAsync();
-        List<ServiceResource>? resources = JsonSerializer.Deserialize<List<ServiceResource>>(responseContent, new System.Text.Json.JsonSerializerOptions() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }) as List<ServiceResource>;
+        List<ServiceResource>? resources = JsonSerializer.Deserialize<List<ServiceResource>>(responseContent, _jsonOptions) as List<ServiceResource>;
 
         Assert.NotNull(resources);
         Assert.NotEmpty(resources);
@@ -525,7 +527,7 @@ public class ResourceControllerWithDbTests(DbFixture dbFixture, WebApplicationFi
         HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
 
         string responseContent = await response.Content.ReadAsStringAsync();
-        List<ServiceResource>? resources = JsonSerializer.Deserialize<List<ServiceResource>>(responseContent, new System.Text.Json.JsonSerializerOptions() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }) as List<ServiceResource>;
+        List<ServiceResource>? resources = JsonSerializer.Deserialize<List<ServiceResource>>(responseContent, _jsonOptions) as List<ServiceResource>;
 
         Assert.NotNull(resources);
         Assert.Empty(resources);
@@ -546,7 +548,7 @@ public class ResourceControllerWithDbTests(DbFixture dbFixture, WebApplicationFi
         HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
 
         string responseContent = await response.Content.ReadAsStringAsync();
-        List<ServiceResource>? resources = JsonSerializer.Deserialize<List<ServiceResource>>(responseContent, new System.Text.Json.JsonSerializerOptions() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }) as List<ServiceResource>;
+        List<ServiceResource>? resources = JsonSerializer.Deserialize<List<ServiceResource>>(responseContent, _jsonOptions) as List<ServiceResource>;
 
         Assert.NotNull(resources);
         Assert.NotEmpty(resources);
@@ -568,7 +570,7 @@ public class ResourceControllerWithDbTests(DbFixture dbFixture, WebApplicationFi
         HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
 
         string responseContent = await response.Content.ReadAsStringAsync();
-        List<ServiceResource>? resources = JsonSerializer.Deserialize<List<ServiceResource>>(responseContent, new System.Text.Json.JsonSerializerOptions() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }) as List<ServiceResource>;
+        List<ServiceResource>? resources = JsonSerializer.Deserialize<List<ServiceResource>>(responseContent, _jsonOptions) as List<ServiceResource>;
 
         Assert.NotNull(resources);
         Assert.Empty(resources);
@@ -595,7 +597,7 @@ public class ResourceControllerWithDbTests(DbFixture dbFixture, WebApplicationFi
         HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
 
         string responseContent = await response.Content.ReadAsStringAsync();
-        List<ServiceResource>? matchingResources = JsonSerializer.Deserialize<List<ServiceResource>>(responseContent, new System.Text.Json.JsonSerializerOptions() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }) as List<ServiceResource>;
+        List<ServiceResource>? matchingResources = JsonSerializer.Deserialize<List<ServiceResource>>(responseContent, _jsonOptions) as List<ServiceResource>;
 
         Assert.NotNull(matchingResources);
         Assert.Single(matchingResources);
@@ -616,7 +618,7 @@ public class ResourceControllerWithDbTests(DbFixture dbFixture, WebApplicationFi
         };
         HttpResponseMessage responseAllResources = await client.SendAsync(httpRequestMessageAllResources);
         string responseContentAllResources = await responseAllResources.Content.ReadAsStringAsync();
-        List<ServiceResource>? allResources = JsonSerializer.Deserialize<List<ServiceResource>>(responseContentAllResources, new System.Text.Json.JsonSerializerOptions() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }) as List<ServiceResource>;
+        List<ServiceResource>? allResources = JsonSerializer.Deserialize<List<ServiceResource>>(responseContentAllResources, _jsonOptions) as List<ServiceResource>;
 
         Assert.NotNull(allResources);
         Assert.True(allResources.Count > 1, "Expected multiple resources in test data");
@@ -640,7 +642,7 @@ public class ResourceControllerWithDbTests(DbFixture dbFixture, WebApplicationFi
         HttpResponseMessage responseSearch = await client.SendAsync(httpRequestMessageSearch);
 
         string responseContentSearch = await responseSearch.Content.ReadAsStringAsync();
-        List<ServiceResource>? matchingResources = JsonSerializer.Deserialize<List<ServiceResource>>(responseContentSearch, new System.Text.Json.JsonSerializerOptions() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }) as List<ServiceResource>;
+        List<ServiceResource>? matchingResources = JsonSerializer.Deserialize<List<ServiceResource>>(responseContentSearch, _jsonOptions) as List<ServiceResource>;
 
         Assert.NotNull(matchingResources);
         Assert.Single(matchingResources);
@@ -657,7 +659,7 @@ public class ResourceControllerWithDbTests(DbFixture dbFixture, WebApplicationFi
         HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
 
         string responseContent = await response.Content.ReadAsStringAsync();
-        ServiceResource? resource = JsonSerializer.Deserialize<ServiceResource>(responseContent, new System.Text.Json.JsonSerializerOptions() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }) as ServiceResource;
+        ServiceResource? resource = JsonSerializer.Deserialize<ServiceResource>(responseContent, _jsonOptions) as ServiceResource;
 
         Assert.NotNull(resource);
         Assert.Equal("skd-migrert-4628-1", resource.Identifier);
@@ -671,7 +673,7 @@ public class ResourceControllerWithDbTests(DbFixture dbFixture, WebApplicationFi
         };
         HttpResponseMessage responseWithVersion = await client.SendAsync(httpRequestMessageWithVersion);
         string responseContentWithVersion = await responseWithVersion.Content.ReadAsStringAsync();
-        ServiceResource? resourceWithVersion = JsonSerializer.Deserialize<ServiceResource>(responseContentWithVersion, new System.Text.Json.JsonSerializerOptions() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }) as ServiceResource;  
+        ServiceResource? resourceWithVersion = JsonSerializer.Deserialize<ServiceResource>(responseContentWithVersion, _jsonOptions) as ServiceResource;  
         Assert.NotNull(resourceWithVersion);
         Assert.Equal("skd-migrert-4628-1", resourceWithVersion.Identifier);
         Assert.Equal(oldVersion.VersionId, resourceWithVersion.VersionId);
@@ -738,7 +740,7 @@ public class ResourceControllerWithDbTests(DbFixture dbFixture, WebApplicationFi
 
         Assert.Equal(HttpStatusCode.OK, responseGet.StatusCode);
 
-        ServiceResource? createdResource = JsonSerializer.Deserialize<ServiceResource>(await responseGet.Content.ReadAsStringAsync(), new System.Text.Json.JsonSerializerOptions() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }) as ServiceResource;
+        ServiceResource? createdResource = JsonSerializer.Deserialize<ServiceResource>(await responseGet.Content.ReadAsStringAsync(), _jsonOptions) as ServiceResource;
 
         Assert.NotNull(createdResource);
 
@@ -782,7 +784,7 @@ public class ResourceControllerWithDbTests(DbFixture dbFixture, WebApplicationFi
 
         Assert.Equal(HttpStatusCode.OK, responseGetUpdated.StatusCode);
 
-        ServiceResource? updatedResource = JsonSerializer.Deserialize<ServiceResource>(await responseGetUpdated.Content.ReadAsStringAsync(), new System.Text.Json.JsonSerializerOptions() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }) as ServiceResource;
+        ServiceResource? updatedResource = JsonSerializer.Deserialize<ServiceResource>(await responseGetUpdated.Content.ReadAsStringAsync(), _jsonOptions) as ServiceResource;
 
         Assert.NotNull(updatedResource);
 
@@ -803,7 +805,7 @@ public class ResourceControllerWithDbTests(DbFixture dbFixture, WebApplicationFi
         HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
 
         string responseContent = await response.Content.ReadAsStringAsync();
-        List<ServiceResource>? resource = JsonSerializer.Deserialize<List<ServiceResource>>(responseContent, new System.Text.Json.JsonSerializerOptions() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }) as List<ServiceResource>;
+        List<ServiceResource>? resource = JsonSerializer.Deserialize<List<ServiceResource>>(responseContent, _jsonOptions) as List<ServiceResource>;
 
         Assert.NotNull(resource);
         Assert.Equal(6, resource.Count);

--- a/test/Altinn.ResourceRegistry.Tests/ResourceControllerWithDbTests.cs
+++ b/test/Altinn.ResourceRegistry.Tests/ResourceControllerWithDbTests.cs
@@ -488,6 +488,92 @@ public class ResourceControllerWithDbTests(DbFixture dbFixture, WebApplicationFi
         Assert.Single(resource);
     }
 
+    [Fact]
+    public async Task SearchResources_ByOrgCode_Ok()
+    {
+        await LoadTestData();
+
+        var client = CreateClient();
+        string requestUri = "resourceregistry/api/v1/Resource/Search?OrgCode=dsb";
+
+        HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri)
+        {
+        };
+
+        HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+
+        string responseContent = await response.Content.ReadAsStringAsync();
+        List<ServiceResource>? resources = JsonSerializer.Deserialize<List<ServiceResource>>(responseContent, new System.Text.Json.JsonSerializerOptions() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }) as List<ServiceResource>;
+
+        Assert.NotNull(resources);
+        Assert.NotEmpty(resources);
+        Assert.All(resources, r => Assert.Equal("dsb", r.HasCompetentAuthority?.Orgcode, ignoreCase: true));
+    }
+
+    [Fact]
+    public async Task SearchResources_ByOrgCode_NoMatch()
+    {
+        await LoadTestData();
+
+        var client = CreateClient();
+        string requestUri = "resourceregistry/api/v1/Resource/Search?OrgCode=nonexistentorg";
+
+        HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri)
+        {
+        };
+
+        HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+
+        string responseContent = await response.Content.ReadAsStringAsync();
+        List<ServiceResource>? resources = JsonSerializer.Deserialize<List<ServiceResource>>(responseContent, new System.Text.Json.JsonSerializerOptions() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }) as List<ServiceResource>;
+
+        Assert.NotNull(resources);
+        Assert.Empty(resources);
+    }
+
+    [Fact]
+    public async Task SearchResources_ByOrganizationId_Ok()
+    {
+        await LoadTestData();
+
+        var client = CreateClient();
+        string requestUri = "resourceregistry/api/v1/Resource/Search?OrganizationId=974760983";
+
+        HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri)
+        {
+        };
+
+        HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+
+        string responseContent = await response.Content.ReadAsStringAsync();
+        List<ServiceResource>? resources = JsonSerializer.Deserialize<List<ServiceResource>>(responseContent, new System.Text.Json.JsonSerializerOptions() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }) as List<ServiceResource>;
+
+        Assert.NotNull(resources);
+        Assert.NotEmpty(resources);
+        Assert.All(resources, r => Assert.Equal("974760983", r.HasCompetentAuthority?.Organization));
+    }
+
+    [Fact]
+    public async Task SearchResources_ByOrganizationId_NoMatch()
+    {
+        await LoadTestData();
+
+        var client = CreateClient();
+        string requestUri = "resourceregistry/api/v1/Resource/Search?OrganizationId=000000000";
+
+        HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri)
+        {
+        };
+
+        HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+
+        string responseContent = await response.Content.ReadAsStringAsync();
+        List<ServiceResource>? resources = JsonSerializer.Deserialize<List<ServiceResource>>(responseContent, new System.Text.Json.JsonSerializerOptions() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }) as List<ServiceResource>;
+
+        Assert.NotNull(resources);
+        Assert.Empty(resources);
+    }
+
     /// <summary>
     /// Scenario: Search for resources by ServiceEditionVersion reference
     /// This is relevant when migrating consents from Altinn 2 to Altinn 3 where the consent is tied to a specific version of a service edition


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- a quick and simple expansion of the existing search filter implementation to support orgcode and/or organizationid filter

## Related Issue(s)
- #830

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green
